### PR TITLE
feat: 0425 threads - busy waiting 없는 alarm clock 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ core
 
 # macOS
 .DS_Store
+
+# local study notes
+study/

--- a/pintos/devices/timer.c
+++ b/pintos/devices/timer.c
@@ -90,11 +90,14 @@ timer_elapsed (int64_t then) {
 /* Suspends execution for approximately TICKS timer ticks. */
 void
 timer_sleep (int64_t ticks) {
+	if (ticks <= 0) {
+		return;
+	}
 	int64_t start = timer_ticks ();
 
 	ASSERT (intr_get_level () == INTR_ON);
-	while (timer_elapsed (start) < ticks)
-		thread_yield ();
+	thread_sleep(start+ticks);
+
 }
 
 /* Suspends execution for approximately MS milliseconds. */
@@ -125,6 +128,7 @@ timer_print_stats (void) {
 static void
 timer_interrupt (struct intr_frame *args UNUSED) {
 	ticks++;
+	thread_awake(ticks);
 	thread_tick ();
 }
 

--- a/pintos/devices/timer.c
+++ b/pintos/devices/timer.c
@@ -90,12 +90,14 @@ timer_elapsed (int64_t then) {
 /* Suspends execution for approximately TICKS timer ticks. */
 void
 timer_sleep (int64_t ticks) {
+	int64_t start;
+
 	if (ticks <= 0) {
 		return;
 	}
-	int64_t start = timer_ticks ();
 
 	ASSERT (intr_get_level () == INTR_ON);
+	start = timer_ticks ();
 	thread_sleep(start+ticks);
 
 }

--- a/pintos/include/lib/kernel/list.h
+++ b/pintos/include/lib/kernel/list.h
@@ -78,18 +78,53 @@
  * - "interior element": An element that is not the head or
  * tail, that is, a real list element.  An empty list does
  * not have any interior elements.*/
+/* 한국어로 풀어보면:
+ * 이 파일의 리스트는 "이중 연결 리스트"다.
+ * 즉 각 원소가 앞 원소와 뒤 원소를 둘 다 가리키는 방식이다.
+ *
+ * 이 구현의 중요한 특징은, 리스트 노드를 따로 동적 할당하지 않는다는 점이다.
+ * 대신 리스트에 들어갈 가능성이 있는 구조체가 자기 안에
+ * `struct list_elem` 필드를 직접 포함해야 한다.
+ *
+ * 그래서 리스트는 구조체 전체를 직접 저장하는 것이 아니라,
+ * 각 구조체 안에 들어 있는 `list_elem`들을 줄 세워 관리한다.
+ * 나중에 `list_entry(...)`를 사용하면, 그 `list_elem`이 원래 어느 구조체의 것이었는지
+ * 다시 찾아서 원래 구조체 포인터로 돌아갈 수 있다.
+ *
+ * 예를 들어 `struct thread` 안에 `elem`이 있으면,
+ * 리스트에는 `thread` 전체가 아니라 `thread.elem`이 들어간다.
+ * 그리고 리스트를 순회하다가 `elem`을 꺼낸 뒤,
+ * `list_entry (e, struct thread, elem)`으로 다시 `struct thread *`를 얻는다.
+ *
+ * 용어도 같이 보면 좋다.
+ * - front: 맨 앞 실제 원소
+ * - back: 맨 뒤 실제 원소
+ * - tail: 마지막 원소 바로 뒤에 있는 꼬리용 표시 원소
+ * - beginning: 순방향 순회의 시작점
+ * - head: 첫 원소 바로 앞에 있는 머리용 표시 원소
+ * - reverse beginning: 역방향 순회의 시작점
+ * - interior element: head/tail이 아닌 실제 데이터 원소
+ *
+ * 처음에는 복잡해 보여도 핵심은 이것뿐이다.
+ * "구조체 안에 `list_elem`을 넣고, 리스트는 그 `list_elem`들을 연결한다." */
 
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 
 /* List element. */
+/* 한국어:
+ * 리스트 안에서 원소 하나를 앞뒤와 연결할 때 쓰는 부품이다.
+ * 보통 다른 구조체 안에 필드로 들어간다. */
 struct list_elem {
 	struct list_elem *prev;     /* Previous list element. */
 	struct list_elem *next;     /* Next list element. */
 };
 
 /* List. */
+/* 한국어:
+ * 리스트 전체를 나타내는 구조체다.
+ * `head`, `tail`은 실제 데이터가 아니라 경계 표시용 원소다. */
 struct list {
 	struct list_elem head;      /* List head. */
 	struct list_elem tail;      /* List tail. */
@@ -100,13 +135,18 @@ struct list {
    name of the outer structure STRUCT and the member name MEMBER
    of the list element.  See the big comment at the top of the
    file for an example. */
+/* 한국어:
+ * `LIST_ELEM` 포인터를 다시 "이 elem을 멤버로 갖고 있던 원래 구조체"의 포인터로 바꾼다.
+ * 예를 들어 `struct thread` 안에 `elem`이 있다면,
+ * `list_entry (e, struct thread, elem)`으로 `e`에서 다시 `struct thread *`를 얻는다. */
 #define list_entry(LIST_ELEM, STRUCT, MEMBER)           \
 	((STRUCT *) ((uint8_t *) &(LIST_ELEM)->next     \
-		- offsetof (STRUCT, MEMBER.next)))
+			- offsetof (STRUCT, MEMBER.next)))
 
 void list_init (struct list *);
 
 /* List traversal. */
+/* 한국어: 리스트를 순회할 때 쓰는 함수들. */
 struct list_elem *list_begin (struct list *);
 struct list_elem *list_next (struct list_elem *);
 struct list_elem *list_end (struct list *);
@@ -119,44 +159,54 @@ struct list_elem *list_head (struct list *);
 struct list_elem *list_tail (struct list *);
 
 /* List insertion. */
+/* 한국어: 리스트에 원소를 넣을 때 쓰는 함수들. */
 void list_insert (struct list_elem *, struct list_elem *);
 void list_splice (struct list_elem *before,
-		struct list_elem *first, struct list_elem *last);
+			struct list_elem *first, struct list_elem *last);
 void list_push_front (struct list *, struct list_elem *);
 void list_push_back (struct list *, struct list_elem *);
 
 /* List removal. */
+/* 한국어: 리스트에서 원소를 뺄 때 쓰는 함수들. */
 struct list_elem *list_remove (struct list_elem *);
 struct list_elem *list_pop_front (struct list *);
 struct list_elem *list_pop_back (struct list *);
 
 /* List elements. */
+/* 한국어: 리스트의 맨 앞/뒤 원소를 얻는 함수들. */
 struct list_elem *list_front (struct list *);
 struct list_elem *list_back (struct list *);
 
 /* List properties. */
+/* 한국어: 리스트 길이, 비었는지 여부 같은 성질을 보는 함수들. */
 size_t list_size (struct list *);
 bool list_empty (struct list *);
 
 /* Miscellaneous. */
+/* 한국어: 뒤집기 같은 기타 유틸 함수들. */
 void list_reverse (struct list *);
 
 /* Compares the value of two list elements A and B, given
    auxiliary data AUX.  Returns true if A is less than B, or
    false if A is greater than or equal to B. */
+/* 한국어:
+ * 리스트 원소 둘의 순서를 비교하는 비교 함수 타입이다.
+ * 정렬이나 ordered insert를 할 때 사용한다. */
 typedef bool list_less_func (const struct list_elem *a,
-                             const struct list_elem *b,
-                             void *aux);
+	                             const struct list_elem *b,
+	                             void *aux);
 
 /* Operations on lists with ordered elements. */
+/* 한국어: 정렬된 리스트를 유지하거나 정렬할 때 쓰는 함수들. */
 void list_sort (struct list *,
-                list_less_func *, void *aux);
+	                list_less_func *, void *aux);
 void list_insert_ordered (struct list *, struct list_elem *,
                           list_less_func *, void *aux);
 void list_unique (struct list *, struct list *duplicates,
                   list_less_func *, void *aux);
 
 /* Max and min. */
+/* 한국어: 리스트에서 가장 큰 원소와 가장 작은 원소를 찾는 함수들. */
 struct list_elem *list_max (struct list *, list_less_func *, void *aux);
 struct list_elem *list_min (struct list *, list_less_func *, void *aux);
 

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -138,7 +138,7 @@ struct thread {
 	/* Owned by thread.c. */
 	tid_t tid;                          /* Thread identifier. */
 	enum thread_status status;          /* Thread state. */
-	int64_t	wakeup_tick;
+	int64_t	wakeup_tick;				/* Tick at which this thread should wake. */
 	char name[16];                      /* Name (for debugging purposes). */
 	int priority;                       /* Priority. */
 

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -138,6 +138,7 @@ struct thread {
 	/* Owned by thread.c. */
 	tid_t tid;                          /* Thread identifier. */
 	enum thread_status status;          /* Thread state. */
+	int64_t	wakeup_tick;
 	char name[16];                      /* Name (for debugging purposes). */
 	int priority;                       /* Priority. */
 
@@ -172,6 +173,8 @@ void thread_print_stats (void);
 typedef void thread_func (void *aux);
 tid_t thread_create (const char *name, int priority, thread_func *, void *);
 
+void thread_sleep (int64_t wakeup_tick);
+void thread_awake (int64_t current_tick);
 void thread_block (void);
 void thread_unblock (struct thread *);
 

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -79,12 +79,61 @@ typedef int tid_t;
  * the `magic' member of the running thread's `struct thread' is
  * set to THREAD_MAGIC.  Stack overflow will normally change this
  * value, triggering the assertion. */
+/* 한국어로 풀어보면:
+ * 각 스레드는 자기 전용 4KB 페이지 하나를 가진다.
+ * 그 페이지 맨 아래에는 `struct thread`가 놓이고,
+ * 맨 위쪽에서는 커널 스택이 아래 방향으로 자란다.
+ *
+ * 여기서 스택은 "함수가 일할 때 잠깐 쓰는 작업 공간"이라고 생각하면 된다.
+ * 함수가 끝나면 어디로 돌아갈지, 지역 변수, 잠깐 저장한 값들이 여기에 놓인다.
+ * 커널 스택은 그중에서도 "커널 코드가 실행될 때 쓰는 스택"이다.
+ *
+ * 왜 스레드마다 커널 스택이 따로 필요하냐면,
+ * 각 스레드는 자기만의 함수 호출 흐름과 자기만의 지역 변수 상태를 가져야 하기 때문이다.
+ * 스레드 A가 함수 중간까지 실행하다 멈추고, 나중에 다시 이어서 실행되려면
+ * A가 쓰던 스택 내용이 그대로 남아 있어야 한다.
+ * 그래서 스레드마다 자기 커널 스택을 따로 가진다.
+ *
+ * 즉 `struct thread`와 커널 스택이 같은 4KB 공간을 나눠 쓰는 구조다.
+ * 그래서 둘 중 하나가 너무 커지면 다른 쪽 공간을 침범하게 된다.
+ *
+ * 여기서 중요한 점은 두 가지다.
+ *
+ * 1. `struct thread`를 너무 크게 만들면 안 된다.
+ *    구조체가 커질수록 커널 스택이 사용할 공간이 줄어든다.
+ *    그래서 새 필드를 추가할 때도 "정말 필요한가?"를 생각해야 한다.
+ *
+ * 2. 커널 함수 안에서 큰 지역 배열이나 큰 구조체를 스택에 올리면 안 된다.
+ *    커널 스택은 넓지 않기 때문에, 지역 변수를 크게 잡으면 스택 오버플로우가 나기 쉽다.
+ *    큰 데이터가 필요하면 `malloc()`이나 `palloc_get_page()` 같은 동적 할당을 쓰라는 뜻이다.
+ *
+ * 아주 단순하게 보면, 스레드 하나당 4KB짜리 방 하나가 있고
+ * 방 바닥 쪽에는 `struct thread`가,
+ * 천장 쪽에는 커널 스택이 있는 셈이다.
+ * 바닥 짐을 너무 많이 늘리거나 천장에서 내려오는 스택을 너무 많이 쓰면
+ * 둘이 부딪혀서 망가진다.
+ *
+ * 스택 오버플로우가 나면 보통 아래쪽의 `struct thread` 영역을 덮어쓰게 되고,
+ * 특히 `magic` 값이 망가져서 `thread_current()`의 assertion failure로 먼저 드러날 가능성이 크다.
+ * 그래서 `magic`은 "이 스레드 구조체가 아직 정상인가?"를 검사하는 안전장치 역할을 한다. */
 /* The `elem' member has a dual purpose.  It can be an element in
  * the run queue (thread.c), or it can be an element in a
  * semaphore wait list (synch.c).  It can be used these two ways
  * only because they are mutually exclusive: only a thread in the
  * ready state is on the run queue, whereas only a thread in the
  * blocked state is on a semaphore wait list. */
+/* 한국어로 풀어보면:
+ * `elem`은 스레드를 리스트에 연결할 때 쓰는 연결 부품이다.
+ *
+ * 이 `elem` 하나를 두 군데에서 재사용할 수 있는데,
+ * 그 이유는 READY 상태의 스레드와 BLOCKED 상태의 스레드가
+ * 동시에 같은 `elem`을 서로 다른 리스트에 넣는 일이 없기 때문이다.
+ *
+ * - READY 상태면 run queue에 들어간다.
+ * - BLOCKED 상태면 semaphore wait list에 들어간다.
+ *
+ * 즉 한 순간에 스레드는 둘 중 하나의 줄에만 서 있으므로,
+ * `elem` 하나만 있어도 리스트 연결용으로 충분하다는 뜻이다. */
 struct thread {
 	/* Owned by thread.c. */
 	tid_t tid;                          /* Thread identifier. */

--- a/pintos/lib/kernel/list.c
+++ b/pintos/lib/kernel/list.c
@@ -30,11 +30,29 @@
    without sacrificing this simplicity.  But using two separate
    elements allows us to do a little bit of checking on some
    operations, which can be valuable.) */
+/* 한국어로 풀어보면:
+   이 리스트 구현에는 실제 데이터 원소 말고도 `head`와 `tail`이라는
+   두 개의 표시용 원소가 있다.
+
+   - `head`는 첫 번째 실제 원소 바로 앞
+   - `tail`은 마지막 실제 원소 바로 뒤
+
+   에 놓인다고 생각하면 된다.
+
+   빈 리스트에서는 `head`와 `tail`이 서로 바로 연결되고,
+   원소가 있으면 그 사이에 실제 원소들이 들어간다.
+
+   이렇게 해 두면 "맨 앞에 넣는 경우", "맨 뒤에서 빼는 경우", "빈 리스트인 경우"
+   같은 특수 처리가 크게 줄어든다.
+   예를 들어 `list_remove()`는 조건문 없이 포인터 몇 개만 바꾸면 된다.
+
+   즉 이 구조의 핵심 목적은 리스트 연산을 단순하게 만드는 것이다. */
 
 static bool is_sorted (struct list_elem *a, struct list_elem *b,
 		list_less_func *less, void *aux) UNUSED;
 
 /* Returns true if ELEM is a head, false otherwise. */
+/* 한국어: ELEM이 head 표시 원소이면 true를 반환한다. */
 static inline bool
 is_head (struct list_elem *elem) {
 	return elem != NULL && elem->prev == NULL && elem->next != NULL;
@@ -42,18 +60,21 @@ is_head (struct list_elem *elem) {
 
 /* Returns true if ELEM is an interior element,
    false otherwise. */
+/* 한국어: ELEM이 head/tail이 아닌 실제 데이터 원소이면 true를 반환한다. */
 static inline bool
 is_interior (struct list_elem *elem) {
 	return elem != NULL && elem->prev != NULL && elem->next != NULL;
 }
 
 /* Returns true if ELEM is a tail, false otherwise. */
+/* 한국어: ELEM이 tail 표시 원소이면 true를 반환한다. */
 static inline bool
 is_tail (struct list_elem *elem) {
 	return elem != NULL && elem->prev != NULL && elem->next == NULL;
 }
 
 /* Initializes LIST as an empty list. */
+/* 한국어: LIST를 빈 리스트 상태로 초기화한다. */
 void
 list_init (struct list *list) {
 	ASSERT (list != NULL);
@@ -64,6 +85,7 @@ list_init (struct list *list) {
 }
 
 /* Returns the beginning of LIST.  */
+/* 한국어: LIST의 순방향 시작점을 반환한다. 보통 첫 실제 원소를 가리킨다. */
 struct list_elem *
 list_begin (struct list *list) {
 	ASSERT (list != NULL);
@@ -73,6 +95,10 @@ list_begin (struct list *list) {
 /* Returns the element after ELEM in its list.  If ELEM is the
    last element in its list, returns the list tail.  Results are
    undefined if ELEM is itself a list tail. */
+/* 한국어:
+   ELEM 다음 원소를 반환한다.
+   ELEM이 마지막 실제 원소라면 tail을 반환한다.
+   ELEM 자체가 tail이면 동작이 정의되지 않는다. */
 struct list_elem *
 list_next (struct list_elem *elem) {
 	ASSERT (is_head (elem) || is_interior (elem));
@@ -84,6 +110,9 @@ list_next (struct list_elem *elem) {
    list_end() is often used in iterating through a list from
    front to back.  See the big comment at the top of list.h for
    an example. */
+/* 한국어:
+   LIST의 tail 표시 원소를 반환한다.
+   보통 순방향 순회에서 "끝"을 나타내는 기준으로 사용한다. */
 struct list_elem *
 list_end (struct list *list) {
 	ASSERT (list != NULL);
@@ -92,6 +121,7 @@ list_end (struct list *list) {
 
 /* Returns the LIST's reverse beginning, for iterating through
    LIST in reverse order, from back to front. */
+/* 한국어: LIST를 뒤에서 앞으로 순회할 때 시작점이 되는 원소를 반환한다. */
 struct list_elem *
 list_rbegin (struct list *list) {
 	ASSERT (list != NULL);
@@ -101,6 +131,10 @@ list_rbegin (struct list *list) {
 /* Returns the element before ELEM in its list.  If ELEM is the
    first element in its list, returns the list head.  Results are
    undefined if ELEM is itself a list head. */
+/* 한국어:
+   ELEM 바로 앞 원소를 반환한다.
+   ELEM이 첫 실제 원소라면 head를 반환한다.
+   ELEM 자체가 head이면 동작이 정의되지 않는다. */
 struct list_elem *
 list_prev (struct list_elem *elem) {
 	ASSERT (is_interior (elem) || is_tail (elem));
@@ -120,6 +154,9 @@ list_prev (struct list_elem *elem) {
    ...do something with f...
    }
    */
+/* 한국어:
+   LIST의 head 표시 원소를 반환한다.
+   역방향 순회에서 "끝"을 나타내는 기준점으로 자주 사용한다. */
 struct list_elem *
 list_rend (struct list *list) {
 	ASSERT (list != NULL);
@@ -137,6 +174,9 @@ list_rend (struct list *list) {
    ...
    }
    */
+/* 한국어:
+   LIST의 head를 반환한다.
+   이 함수는 `list_head()` -> `list_next()` 식의 순회 패턴에서 사용할 수 있다. */
 struct list_elem *
 list_head (struct list *list) {
 	ASSERT (list != NULL);
@@ -144,6 +184,7 @@ list_head (struct list *list) {
 }
 
 /* Return's LIST's tail. */
+/* 한국어: LIST의 tail을 반환한다. */
 struct list_elem *
 list_tail (struct list *list) {
 	ASSERT (list != NULL);
@@ -153,6 +194,10 @@ list_tail (struct list *list) {
 /* Inserts ELEM just before BEFORE, which may be either an
    interior element or a tail.  The latter case is equivalent to
    list_push_back(). */
+/* 한국어:
+   ELEM을 BEFORE 바로 앞에 삽입한다.
+   BEFORE는 실제 데이터 원소일 수도 있고 tail일 수도 있다.
+   BEFORE가 tail이면 결국 맨 뒤에 넣는 것과 같다. */
 void
 list_insert (struct list_elem *before, struct list_elem *elem) {
 	ASSERT (is_interior (before) || is_tail (before));
@@ -167,9 +212,12 @@ list_insert (struct list_elem *before, struct list_elem *elem) {
 /* Removes elements FIRST though LAST (exclusive) from their
    current list, then inserts them just before BEFORE, which may
    be either an interior element or a tail. */
+/* 한국어:
+   FIRST부터 LAST 직전까지의 구간을 현재 리스트에서 떼어낸 뒤,
+   BEFORE 바로 앞에 한 덩어리로 끼워 넣는다. */
 void
 list_splice (struct list_elem *before,
-		struct list_elem *first, struct list_elem *last) {
+			struct list_elem *first, struct list_elem *last) {
 	ASSERT (is_interior (before) || is_tail (before));
 	if (first == last)
 		return;
@@ -179,10 +227,12 @@ list_splice (struct list_elem *before,
 	ASSERT (is_interior (last));
 
 	/* Cleanly remove FIRST...LAST from its current list. */
+	/* 한국어: FIRST...LAST 구간을 원래 리스트에서 깔끔하게 분리한다. */
 	first->prev->next = last->next;
 	last->next->prev = first->prev;
 
 	/* Splice FIRST...LAST into new list. */
+	/* 한국어: 분리한 구간을 새 위치(before 앞)에 이어 붙인다. */
 	first->prev = before->prev;
 	last->next = before;
 	before->prev->next = first;
@@ -191,6 +241,7 @@ list_splice (struct list_elem *before,
 
 /* Inserts ELEM at the beginning of LIST, so that it becomes the
    front in LIST. */
+/* 한국어: ELEM을 LIST 맨 앞에 넣는다. */
 void
 list_push_front (struct list *list, struct list_elem *elem) {
 	list_insert (list_begin (list), elem);
@@ -198,6 +249,7 @@ list_push_front (struct list *list, struct list_elem *elem) {
 
 /* Inserts ELEM at the end of LIST, so that it becomes the
    back in LIST. */
+/* 한국어: ELEM을 LIST 맨 뒤에 넣는다. */
 void
 list_push_back (struct list *list, struct list_elem *elem) {
 	list_insert (list_end (list), elem);
@@ -234,9 +286,29 @@ even in that case:
 while (!list_empty (&list))
 {
 struct list_elem *e = list_pop_front (&list);
-...do something with e...
-}
-*/
+	...do something with e...
+	}
+	*/
+/* 한국어:
+   ELEM을 리스트에서 제거하고, 원래 그 뒤에 있던 원소를 반환한다.
+   ELEM이 리스트 안에 없으면 동작이 정의되지 않는다.
+
+   여기서 "원래 그 뒤에 있던 원소"는
+   제거하기 전 기준으로 `ELEM->next`였던 원소를 뜻한다.
+   예를 들어:
+
+   head <-> A <-> ELEM <-> B <-> tail
+
+   에서 `list_remove (ELEM)`을 하면,
+   ELEM은 빠지고 함수는 `B`를 반환한다.
+   만약 ELEM이 마지막 실제 원소였다면, 그 뒤 원소는 `tail`이다.
+
+   중요한 점은, 제거한 뒤의 ELEM을 여전히 리스트 원소처럼 다루면 안 된다는 것이다.
+   즉 `list_remove(e)`를 한 뒤에 `list_next(e)` 같은 걸 호출하면 안 된다.
+
+   그래서 원소를 순회하며 제거할 때는
+   `e = list_remove(e)` 패턴을 쓰거나,
+   더 안전하게는 앞에서 하나씩 `list_pop_front()`로 꺼내는 방식을 쓴다. */
 struct list_elem *
 list_remove (struct list_elem *elem) {
 	ASSERT (is_interior (elem));
@@ -247,6 +319,7 @@ list_remove (struct list_elem *elem) {
 
 /* Removes the front element from LIST and returns it.
    Undefined behavior if LIST is empty before removal. */
+/* 한국어: LIST 맨 앞 원소를 제거해서 반환한다. 빈 리스트면 동작이 정의되지 않는다. */
 struct list_elem *
 list_pop_front (struct list *list) {
 	struct list_elem *front = list_front (list);
@@ -256,6 +329,7 @@ list_pop_front (struct list *list) {
 
 /* Removes the back element from LIST and returns it.
    Undefined behavior if LIST is empty before removal. */
+/* 한국어: LIST 맨 뒤 원소를 제거해서 반환한다. 빈 리스트면 동작이 정의되지 않는다. */
 struct list_elem *
 list_pop_back (struct list *list) {
 	struct list_elem *back = list_back (list);
@@ -265,6 +339,7 @@ list_pop_back (struct list *list) {
 
 /* Returns the front element in LIST.
    Undefined behavior if LIST is empty. */
+/* 한국어: LIST의 맨 앞 실제 원소를 반환한다. 빈 리스트면 동작이 정의되지 않는다. */
 struct list_elem *
 list_front (struct list *list) {
 	ASSERT (!list_empty (list));
@@ -273,6 +348,7 @@ list_front (struct list *list) {
 
 /* Returns the back element in LIST.
    Undefined behavior if LIST is empty. */
+/* 한국어: LIST의 맨 뒤 실제 원소를 반환한다. 빈 리스트면 동작이 정의되지 않는다. */
 struct list_elem *
 list_back (struct list *list) {
 	ASSERT (!list_empty (list));
@@ -281,6 +357,7 @@ list_back (struct list *list) {
 
 /* Returns the number of elements in LIST.
    Runs in O(n) in the number of elements. */
+/* 한국어: LIST 안 실제 원소 개수를 세어 반환한다. 시간 복잡도는 O(n)이다. */
 size_t
 list_size (struct list *list) {
 	struct list_elem *e;
@@ -292,12 +369,14 @@ list_size (struct list *list) {
 }
 
 /* Returns true if LIST is empty, false otherwise. */
+/* 한국어: LIST가 비어 있으면 true, 아니면 false를 반환한다. */
 bool
 list_empty (struct list *list) {
 	return list_begin (list) == list_end (list);
 }
 
 /* Swaps the `struct list_elem *'s that A and B point to. */
+/* 한국어: A와 B가 가리키는 `struct list_elem *` 값을 서로 바꾼다. */
 static void
 swap (struct list_elem **a, struct list_elem **b) {
 	struct list_elem *t = *a;
@@ -306,6 +385,7 @@ swap (struct list_elem **a, struct list_elem **b) {
 }
 
 /* Reverses the order of LIST. */
+/* 한국어: LIST의 원소 순서를 뒤집는다. */
 void
 list_reverse (struct list *list) {
 	if (!list_empty (list)) {
@@ -320,6 +400,8 @@ list_reverse (struct list *list) {
 
 /* Returns true only if the list elements A through B (exclusive)
    are in order according to LESS given auxiliary data AUX. */
+/* 한국어:
+   A부터 B 직전까지의 구간이 LESS 기준으로 정렬되어 있을 때만 true를 반환한다. */
 static bool
 is_sorted (struct list_elem *a, struct list_elem *b,
 		list_less_func *less, void *aux) {
@@ -335,6 +417,10 @@ is_sorted (struct list_elem *a, struct list_elem *b,
    given auxiliary data AUX.  Returns the (exclusive) end of the
    run.
    A through B (exclusive) must form a non-empty range. */
+/* 한국어:
+   A에서 시작해서 B를 넘지 않는 범위 안에서,
+   LESS 기준으로 오름차순이 유지되는 연속 구간(run)을 찾는다.
+   반환값은 그 구간의 끝 다음 위치(exclusive end)다. */
 static struct list_elem *
 find_end_of_run (struct list_elem *a, struct list_elem *b,
 		list_less_func *less, void *aux) {
@@ -354,6 +440,9 @@ find_end_of_run (struct list_elem *a, struct list_elem *b,
    (exclusive).  Both input ranges must be nonempty and sorted in
    nondecreasing order according to LESS given auxiliary data
    AUX.  The output range will be sorted the same way. */
+/* 한국어:
+   정렬되어 있는 두 구간 A0...A1B0, A1B0...B1을 제자리에서 합쳐
+   하나의 더 큰 정렬 구간으로 만든다. */
 static void
 inplace_merge (struct list_elem *a0, struct list_elem *a1b0,
 		struct list_elem *b1,
@@ -377,6 +466,10 @@ inplace_merge (struct list_elem *a0, struct list_elem *a1b0,
 /* Sorts LIST according to LESS given auxiliary data AUX, using a
    natural iterative merge sort that runs in O(n lg n) time and
    O(1) space in the number of elements in LIST. */
+/* 한국어:
+   LIST를 LESS 기준으로 정렬한다.
+   자연 병합 정렬(natural iterative merge sort)을 사용하며,
+   시간 복잡도는 O(n log n), 추가 공간은 O(1)이다. */
 void
 list_sort (struct list *list, list_less_func *less, void *aux) {
 	size_t output_run_cnt;        /* Number of runs output in current pass. */
@@ -384,8 +477,9 @@ list_sort (struct list *list, list_less_func *less, void *aux) {
 	ASSERT (list != NULL);
 	ASSERT (less != NULL);
 
-	/* Pass over the list repeatedly, merging adjacent runs of
-	   nondecreasing elements, until only one run is left. */
+		/* Pass over the list repeatedly, merging adjacent runs of
+		   nondecreasing elements, until only one run is left. */
+		/* 한국어: 정렬된 구간(run)들을 반복해서 합쳐 하나만 남을 때까지 진행한다. */
 	do {
 		struct list_elem *a0;     /* Start of first run. */
 		struct list_elem *a1b0;   /* End of first run, start of second. */
@@ -394,16 +488,19 @@ list_sort (struct list *list, list_less_func *less, void *aux) {
 		output_run_cnt = 0;
 		for (a0 = list_begin (list); a0 != list_end (list); a0 = b1) {
 			/* Each iteration produces one output run. */
+			/* 한국어: 한 번 돌 때마다 출력 구간 하나가 만들어진다. */
 			output_run_cnt++;
 
 			/* Locate two adjacent runs of nondecreasing elements
 			   A0...A1B0 and A1B0...B1. */
+			/* 한국어: 서로 인접한 두 개의 정렬 구간을 찾는다. */
 			a1b0 = find_end_of_run (a0, list_end (list), less, aux);
 			if (a1b0 == list_end (list))
 				break;
 			b1 = find_end_of_run (a1b0, list_end (list), less, aux);
 
 			/* Merge the runs. */
+			/* 한국어: 찾은 두 정렬 구간을 병합한다. */
 			inplace_merge (a0, a1b0, b1, less, aux);
 		}
 	}
@@ -415,6 +512,9 @@ list_sort (struct list *list, list_less_func *less, void *aux) {
 /* Inserts ELEM in the proper position in LIST, which must be
    sorted according to LESS given auxiliary data AUX.
    Runs in O(n) average case in the number of elements in LIST. */
+/* 한국어:
+   이미 정렬되어 있는 LIST 안에서 ELEM이 들어가야 할 올바른 위치를 찾아 삽입한다.
+   평균 시간 복잡도는 O(n)이다. */
 void
 list_insert_ordered (struct list *list, struct list_elem *elem,
 		list_less_func *less, void *aux) {
@@ -434,6 +534,9 @@ list_insert_ordered (struct list *list, struct list_elem *elem,
    set of adjacent elements that are equal according to LESS
    given auxiliary data AUX.  If DUPLICATES is non-null, then the
    elements from LIST are appended to DUPLICATES. */
+/* 한국어:
+   LIST를 순회하면서 서로 인접한 중복 원소들 중 첫 번째만 남기고 나머지를 제거한다.
+   DUPLICATES가 NULL이 아니면, 제거한 중복 원소들은 DUPLICATES 뒤에 붙인다. */
 void
 list_unique (struct list *list, struct list *duplicates,
 		list_less_func *less, void *aux) {
@@ -458,6 +561,10 @@ list_unique (struct list *list, struct list *duplicates,
    to LESS given auxiliary data AUX.  If there is more than one
    maximum, returns the one that appears earlier in the list.  If
    the list is empty, returns its tail. */
+/* 한국어:
+   LESS 기준으로 가장 큰 원소를 반환한다.
+   최댓값이 여러 개면 리스트에서 더 앞에 있는 것을 반환한다.
+   빈 리스트면 tail을 반환한다. */
 struct list_elem *
 list_max (struct list *list, list_less_func *less, void *aux) {
 	struct list_elem *max = list_begin (list);
@@ -475,6 +582,10 @@ list_max (struct list *list, list_less_func *less, void *aux) {
    to LESS given auxiliary data AUX.  If there is more than one
    minimum, returns the one that appears earlier in the list.  If
    the list is empty, returns its tail. */
+/* 한국어:
+   LESS 기준으로 가장 작은 원소를 반환한다.
+   최솟값이 여러 개면 리스트에서 더 앞에 있는 것을 반환한다.
+   빈 리스트면 tail을 반환한다. */
 struct list_elem *
 list_min (struct list *list, list_less_func *less, void *aux) {
 	struct list_elem *min = list_begin (list);

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -28,6 +28,9 @@
    that are ready to run but not actually running. */
 static struct list ready_list;
 
+/* Sleeping List */
+static struct list sleep_list;
+
 /* Idle thread. */
 static struct thread *idle_thread;
 
@@ -108,6 +111,7 @@ thread_init (void) {
 	/* Init the globla thread context */
 	lock_init (&tid_lock);
 	list_init (&ready_list);
+	list_init (&sleep_list);
 	list_init (&destruction_req);
 
 	/* Set up a thread structure for the running thread. */
@@ -210,6 +214,21 @@ thread_create (const char *name, int priority,
 	return tid;
 }
 
+void
+thread_sleep (int64_t wakeup_tick) {
+	enum intr_level old_level;
+	old_level = intr_disable ();
+
+	struct thread *curr = thread_current();
+	curr->wakeup_tick = wakeup_tick;
+
+	if (curr != idle_thread)
+		list_push_back (&sleep_list, &curr->elem);
+
+	thread_block();
+	intr_set_level (old_level);
+}
+
 /* Puts the current thread to sleep.  It will not be scheduled
    again until awoken by thread_unblock().
 
@@ -223,6 +242,28 @@ thread_block (void) {
 	thread_current ()->status = THREAD_BLOCKED;
 	schedule ();
 }
+
+void
+thread_awake (int64_t current_tick){
+	/*sleep_list를 처음부터 끝까지 순회할 방법이 있나*/
+	struct list_elem *e = list_begin(&sleep_list);
+	while (e != list_end(&sleep_list)) {
+		struct thread *t = list_entry(e, struct thread, elem);
+		struct list_elem *next = list_next(e);
+		/*만약 sleep_list의 원소가 들어있는 스레드의 wakeup_tick이 current_tick보다 작거나 같으면*/
+		/*해당 원소를 sleep_list에서 꺼내고, 해당 원소가 들어있는 스레드를 thread_unblock()한다*/
+		if (t->wakeup_tick <= current_tick) {
+			list_remove(e);
+			thread_unblock(t);
+		}
+		e = next;
+	}
+}
+/*
+인터럽트 핸들러에서 매 tick마다 sleep_list 전체를 끝까지 도는 구조라, 스레드가 늘면 timer_interrupt()가 무거워질 수 있어요.
+thread.c (line 247), timer.c (line 129)
+지금 구현은 동작 방향은 맞지만, 리스트가 정렬돼 있지 않아서 매 tick 전체 순회를 강제합니다. 작은 테스트는 버틸 수 있어도, 인터럽트 핸들러는 가능한 짧게 끝내는 쪽이 안전해요. 정렬된 sleep_list를 유지하면 앞부분만 보고 멈출 수 있어서 더 낫습니다.
+*/
 
 /* Transitions a blocked thread T to the ready-to-run state.
    This is an error if T is not blocked.  (Use thread_yield() to

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -66,6 +66,8 @@ static void do_schedule(int status);
 static void schedule (void);
 static tid_t allocate_tid (void);
 
+static bool wakeup_less (const struct list_elem *a, const struct list_elem *b, void *aux UNUSED);
+
 /* Returns true if T appears to point to a valid thread. */
 #define is_thread(t) ((t) != NULL && (t)->magic == THREAD_MAGIC)
 
@@ -217,13 +219,14 @@ thread_create (const char *name, int priority,
 void
 thread_sleep (int64_t wakeup_tick) {
 	enum intr_level old_level;
-	old_level = intr_disable ();
-
 	struct thread *curr = thread_current();
+	
+	old_level = intr_disable ();
 	curr->wakeup_tick = wakeup_tick;
 
 	if (curr != idle_thread)
-		list_push_back (&sleep_list, &curr->elem);
+		// 이전 코드 list_push_back (&sleep_list, &curr->elem);
+		list_insert_ordered (&sleep_list, &curr->elem, wakeup_less, NULL);
 
 	thread_block();
 	intr_set_level (old_level);
@@ -243,15 +246,16 @@ thread_block (void) {
 	schedule ();
 }
 
+/* 원래 썼던 코드 
 void
 thread_awake (int64_t current_tick){
-	/*sleep_list를 처음부터 끝까지 순회할 방법이 있나*/
+	// sleep_list를 처음부터 끝까지 순회할 방법이 있나
 	struct list_elem *e = list_begin(&sleep_list);
 	while (e != list_end(&sleep_list)) {
 		struct thread *t = list_entry(e, struct thread, elem);
 		struct list_elem *next = list_next(e);
-		/*만약 sleep_list의 원소가 들어있는 스레드의 wakeup_tick이 current_tick보다 작거나 같으면*/
-		/*해당 원소를 sleep_list에서 꺼내고, 해당 원소가 들어있는 스레드를 thread_unblock()한다*/
+		// 만약 sleep_list의 원소가 들어있는 스레드의 wakeup_tick이 current_tick보다 작거나 같으면
+		//해당 원소를 sleep_list에서 꺼내고, 해당 원소가 들어있는 스레드를 thread_unblock()한다
 		if (t->wakeup_tick <= current_tick) {
 			list_remove(e);
 			thread_unblock(t);
@@ -259,11 +263,25 @@ thread_awake (int64_t current_tick){
 		e = next;
 	}
 }
-/*
+
 인터럽트 핸들러에서 매 tick마다 sleep_list 전체를 끝까지 도는 구조라, 스레드가 늘면 timer_interrupt()가 무거워질 수 있어요.
 thread.c (line 247), timer.c (line 129)
 지금 구현은 동작 방향은 맞지만, 리스트가 정렬돼 있지 않아서 매 tick 전체 순회를 강제합니다. 작은 테스트는 버틸 수 있어도, 인터럽트 핸들러는 가능한 짧게 끝내는 쪽이 안전해요. 정렬된 sleep_list를 유지하면 앞부분만 보고 멈출 수 있어서 더 낫습니다.
 */
+
+void
+thread_awake (int64_t current_tick) {
+	while (!list_empty (&sleep_list)) {
+		struct thread *t;
+
+		t = list_entry (list_front (&sleep_list), struct thread, elem);
+		if (t->wakeup_tick > current_tick) {
+			break;
+		}
+		list_pop_front (&sleep_list);
+		thread_unblock (t);
+	}
+}
 
 /* Transitions a blocked thread T to the ready-to-run state.
    This is an error if T is not blocked.  (Use thread_yield() to
@@ -284,6 +302,17 @@ thread_unblock (struct thread *t) {
 	list_push_back (&ready_list, &t->elem);
 	t->status = THREAD_READY;
 	intr_set_level (old_level);
+}
+
+static bool
+wakeup_less (const struct list_elem *a, const struct list_elem *b, void *aux UNUSED) {
+	struct thread *ta = list_entry (a, struct thread, elem);
+	struct thread *tb = list_entry (b, struct thread, elem);
+
+	if (ta->wakeup_tick != tb->wakeup_tick)
+		return ta->wakeup_tick < tb->wakeup_tick;
+
+	return ta->priority > tb->priority;
 }
 
 /* Returns the name of the running thread. */


### PR DESCRIPTION
## 요약
- busy waiting 없이 동작하는 Alarm Clock 기능을 구현했습니다.
- 각 스레드가 깨어나야 할 시점을 저장할 수 있도록 `wakeup_tick`을 추가했습니다.
- 잠든 스레드를 관리하기 위한 `sleep_list`를 도입했습니다.
- `timer_sleep()`가 지정된 tick 동안 현재 스레드를 block하도록 변경했습니다.
- timer interrupt 시점에 깨어나야 하는 스레드를 깨우도록 구현했습니다.

## 변경 이유
기존 sleep 방식은 CPU를 비효율적으로 사용할 수 있기 때문에,
스레드를 실제로 block 시킨 뒤 필요한 시점에만 다시 깨우는 방식으로 변경했습니다.
이를 통해 busy waiting을 제거하고 CPU 자원을 더 효율적으로 사용할 수 있습니다.

## 주요 변경 사항
### `thread.h`
- `struct thread`에 `wakeup_tick` 필드 추가
- `thread_sleep()`, `thread_awake()` 함수 선언 추가

### `thread.c`
- 잠든 스레드를 관리하기 위한 `sleep_list` 추가
- 현재 스레드를 재울 수 있는 `thread_sleep()` 구현
- 현재 tick 기준으로 깨어나야 하는 스레드를 깨우는 `thread_awake()` 구현

### `timer.c`
- `timer_sleep()`가 busy waiting 대신 스레드를 block하도록 변경
- `timer_interrupt()`에서 wake-up 로직을 수행하도록 변경

## 이외 변경 사항
### `list.h`, `thread.h`, `list.c`, `thread.c`
- 한글 주석 추가

## 테스트
- [x] `alarm-zero`
- [x] `alarm-single`
- [x] `alarm-multiple`
- [x] `alarm-simultaneous`
- [x] `alarm-negative`
- [ ] `alarm-priority`