### PR TITLE
[priority-sema] priority-sema 대기열 우선순위 기반 깨우기 구현

### DIFF
--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -141,6 +141,9 @@ int thread_get_nice (void);
 void thread_set_nice (int);
 int thread_get_recent_cpu (void);
 int thread_get_load_avg (void);
+bool cmp_priority(const struct list_elem *a,
+				  const struct list_elem *b,
+				  void *aux);
 
 void do_iret (struct intr_frame *tf);
 

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -40,6 +40,9 @@
 
    - up 또는 "V": 값을 증가시키고, 대기 중인 스레드가 있으면
      하나를 깨운다. */
+
+static bool wake_up_less(const struct list_elem *, const struct list_elem *, void *aux);
+
 void
 sema_init (struct semaphore *sema, unsigned value) {
 	ASSERT (sema != NULL);
@@ -63,7 +66,7 @@ sema_down (struct semaphore *sema) {
 
 	old_level = intr_disable ();
 	while (sema->value == 0) {
-		list_push_back (&sema->waiters, &thread_current ()->elem);
+		list_insert_ordered(&sema->waiters, &thread_current()->elem, cmp_priority, NULL);
 		thread_block ();
 	}
 	sema->value--;
@@ -106,11 +109,27 @@ sema_up (struct semaphore *sema) {
 	ASSERT (sema != NULL);
 
 	old_level = intr_disable ();
-	if (!list_empty (&sema->waiters))
-		thread_unblock (list_entry (list_pop_front (&sema->waiters),
-					struct thread, elem));
+	bool should_yield = false;
+
+	struct thread *cur = thread_current();
+	if (!list_empty (&sema->waiters)) {
+		struct thread *waiter = list_entry(list_pop_front(&sema->waiters),
+										   struct thread, elem);
+		thread_unblock(waiter);
+		if (cur->priority < waiter->priority) {
+			if (intr_context()) {
+				intr_yield_on_return();
+			} else {
+				should_yield = true;
+			}
+		}
+	}
 	sema->value++;
-	intr_set_level (old_level);
+	intr_set_level(old_level);
+
+	if (should_yield) {
+		thread_yield();
+	}
 }
 
 static void sema_test_helper (void *sema_);

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -207,6 +207,8 @@ thread_create (const char *name, int priority,
 
 	/* 실행 큐에 추가한다. */
 	thread_unblock (t);
+	if (priority > thread_current()->priority)
+		thread_yield();
 
 	return tid;
 }
@@ -214,6 +216,7 @@ thread_create (const char *name, int priority,
 /* `wakeup_tick` 시각이 된 스레드들을 깨운다. */
 void thread_awake(int64_t now) {
 	while  (!(list_empty(&sleep_list))) {
+		
 	struct list_elem *head = list_begin(&sleep_list);
 	struct thread *t = list_entry(head, struct thread, elem);
 	if (t->wakeup_tick > now) 
@@ -263,6 +266,14 @@ static bool wake_up_less (const struct list_elem *a, const struct list_elem *b, 
 		return ta->wakeup_tick < tb->wakeup_tick;
 }
 
+bool cmp_priority(const struct list_elem *a, const struct list_elem *b, void *aux UNUSED)
+{
+	struct thread *ta = list_entry(a, struct thread, elem);
+	struct thread *tb = list_entry(b, struct thread, elem);
+
+	return ta->priority > tb->priority;
+}
+
 /* 블록된 스레드 `T`를 실행 가능한 준비 상태로 바꾼다.
    `T`가 블록 상태가 아니면 오류다. (실행 중인 스레드를 준비 상태로
    만들려면 `thread_yield()`를 써라.)
@@ -278,7 +289,7 @@ thread_unblock (struct thread *t) {
 
 	old_level = intr_disable ();
 	ASSERT (t->status == THREAD_BLOCKED);
-	list_push_back (&ready_list, &t->elem);
+	list_insert_ordered(&ready_list, &t->elem, cmp_priority, NULL);
 	t->status = THREAD_READY;
 	intr_set_level (old_level);
 }
@@ -340,7 +351,7 @@ thread_yield (void) {
 
 	old_level = intr_disable ();
 	if (curr != idle_thread)
-		list_push_back (&ready_list, &curr->elem);
+		list_insert_ordered(&ready_list, &curr->elem, cmp_priority, NULL);
 	do_schedule (THREAD_READY);
 	intr_set_level (old_level);
 }


### PR DESCRIPTION
## 변경 내용
- `sema_down()`에서 세마포어 대기열(`waiters`)을 우선순위 기준으로 관리하도록 수정했습니다.
- `sema_up()`에서 대기 중인 스레드 중 가장 높은 우선순위 스레드를 먼저 깨우도록 반영했습니다.
- 우선순위가 높은 스레드가 깨어났을 때 실행 순서가 맞도록 스케줄링 흐름을 함께 점검했습니다.

## 테스트

| 테스트 | 결과 |
| --- | --- |
| `priority-sema` | PASS |

## 리뷰 포인트
- 현재 PR은 `priority-sema` 통과를 목표로 우선 적용한 변경입니다.
- `priority-condvar` 및 다른 `priority-*` 테스트와의 상호 영향은 추가 확인이 필요합니다.
- `ready_list` 우선순위 처리와 `thread_yield()` 동작이 다른 우선순위 테스트에도 일관되게 맞는지 봐주시면 좋겠습니다.

## PR 체크리스트
- [x] 관련 테스트를 직접 돌렸습니다.
- [x] 테스트 결과를 적었습니다.
- [x] 남은 리스크(리뷰 포인트)가 있으면 적었습니다.
