### PR TITLE
[priority] semaphore/condvar 대기열 우선순위 정렬 및 선점 처리 구현

### DIFF
--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -137,6 +137,8 @@ void thread_yield (void);
 int thread_get_priority (void);
 void thread_set_priority (int);
 
+bool thread_priority_less(const struct list_elem *a, const struct list_elem *b, void *aux UNUSED);
+
 int thread_get_nice (void);
 void thread_set_nice (int);
 int thread_get_recent_cpu (void);

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -123,6 +123,9 @@ void thread_print_stats (void);
 typedef void thread_func (void *aux);
 tid_t thread_create (const char *name, int priority, thread_func *, void *);
 
+void thread_awake(int64_t now);
+void thread_sleep(int64_t wakeup_tick);
+
 void thread_sleep (int64_t);
 void thread_block (void);
 void thread_unblock (struct thread *);

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -63,7 +63,7 @@ sema_down (struct semaphore *sema) {
 
 	old_level = intr_disable ();
 	while (sema->value == 0) {
-		list_push_back (&sema->waiters, &thread_current ()->elem);
+		list_insert_ordered(&sema->waiters, &thread_current ()->elem, thread_priority_less, NULL);
 		thread_block ();
 	}
 	sema->value--;
@@ -99,17 +99,33 @@ sema_try_down (struct semaphore *sema) {
    `SEMA` 값을 증가시키고, 대기 중인 스레드가 있으면 하나를 깨운다.
 
    이 함수는 인터럽트 핸들러 안에서 호출할 수 있다. */
-void
-sema_up (struct semaphore *sema) {
+void sema_up (struct semaphore *sema) {
 	enum intr_level old_level;
+	struct thread *t;
 
 	ASSERT (sema != NULL);
 
 	old_level = intr_disable ();
-	if (!list_empty (&sema->waiters))
-		thread_unblock (list_entry (list_pop_front (&sema->waiters),
-					struct thread, elem));
-	sema->value++;
+
+	if (!list_empty (&sema->waiters)) {
+		t = list_entry(list_pop_front(&sema->waiters), struct thread, elem);
+		thread_unblock(t);
+
+		sema->value++;
+
+		if (t->priority > thread_current()->priority) {
+			if (intr_context()) {
+				intr_yield_on_return();
+			}
+			else {
+				thread_yield();
+			}
+		}
+	}
+	else {
+		sema->value++;
+	}
+
 	intr_set_level (old_level);
 }
 
@@ -264,7 +280,7 @@ cond_wait (struct condition *cond, struct lock *lock) {
 	ASSERT (lock_held_by_current_thread (lock));
 
 	sema_init (&waiter.semaphore, 0);
-	list_push_back (&cond->waiters, &waiter.elem);
+	list_insert_ordered(&cond->waiters, &waiter.elem, thread_priority_less, NULL);
 	lock_release (lock);
 	sema_down (&waiter.semaphore);
 	lock_acquire (lock);

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -242,6 +242,7 @@ lock_held_by_current_thread (const struct lock *lock) {
 struct semaphore_elem {
 	struct list_elem elem;              /* 리스트 원소. */
 	struct semaphore semaphore;         /* 해당 세마포어. */
+	int priority;                       /* 원소의 우선순위 */
 };
 
 /* 조건 변수 `COND`를 초기화한다. 조건 변수는 한 코드 조각이
@@ -270,8 +271,7 @@ cond_init (struct condition *cond) {
    이 함수는 잠들 수 있으므로 인터럽트 핸들러 안에서 호출하면
    안 된다. 인터럽트를 끈 상태에서 호출할 수는 있지만, 잠들어야
    하면 인터럽트가 다시 켜진다. */
-void
-cond_wait (struct condition *cond, struct lock *lock) {
+void cond_wait (struct condition *cond, struct lock *lock) {
 	struct semaphore_elem waiter;
 
 	ASSERT (cond != NULL);
@@ -316,4 +316,11 @@ cond_broadcast (struct condition *cond, struct lock *lock) {
 
 	while (!list_empty (&cond->waiters))
 		cond_signal (cond, lock);
+}
+
+bool condition_priority_less(const struct list_elem *a, const struct list_elem *b, void *aux UNUSED) {
+	struct semaphore_elem *sa = list_entry(a, struct semaphore_elem, elem);
+	struct semaphore_elem *sb = list_entry(b, struct semaphore_elem, elem);
+
+	return sa->priority < sb->priority;
 }

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -31,6 +31,8 @@
 #include "threads/interrupt.h"
 #include "threads/thread.h"
 
+static bool condition_priority_less(const struct list_elem *a, const struct list_elem *b, void *aux UNUSED);
+
 /* 세마포어 `SEMA`를 `VALUE`로 초기화한다. 세마포어는
    음수가 아닌 정수 값과, 이를 조작하는 두 개의 원자적 연산으로
    이루어진다.
@@ -280,7 +282,8 @@ void cond_wait (struct condition *cond, struct lock *lock) {
 	ASSERT (lock_held_by_current_thread (lock));
 
 	sema_init (&waiter.semaphore, 0);
-	list_insert_ordered(&cond->waiters, &waiter.elem, thread_priority_less, NULL);
+	waiter.priority = thread_current()->priority;
+	list_insert_ordered(&cond->waiters, &waiter.elem, condition_priority_less, NULL);
 	lock_release (lock);
 	sema_down (&waiter.semaphore);
 	lock_acquire (lock);
@@ -292,16 +295,14 @@ void cond_wait (struct condition *cond, struct lock *lock) {
 
    인터럽트 핸들러는 락을 획득할 수 없으므로, 그 안에서
    조건 변수에 신호를 보내려는 시도도 의미가 없다. */
-void
-cond_signal (struct condition *cond, struct lock *lock UNUSED) {
+void cond_signal (struct condition *cond, struct lock *lock UNUSED) {
 	ASSERT (cond != NULL);
 	ASSERT (lock != NULL);
 	ASSERT (!intr_context ());
 	ASSERT (lock_held_by_current_thread (lock));
 
 	if (!list_empty (&cond->waiters))
-		sema_up (&list_entry (list_pop_front (&cond->waiters),
-					struct semaphore_elem, elem)->semaphore);
+		sema_up (&list_entry (list_pop_front (&cond->waiters), struct semaphore_elem, elem)->semaphore);
 }
 
 /* `COND`에서 기다리는 모든 스레드를 깨운다.
@@ -309,8 +310,7 @@ cond_signal (struct condition *cond, struct lock *lock UNUSED) {
 
    인터럽트 핸들러는 락을 획득할 수 없으므로, 그 안에서
    조건 변수에 신호를 보내려는 시도도 의미가 없다. */
-void
-cond_broadcast (struct condition *cond, struct lock *lock) {
+void cond_broadcast (struct condition *cond, struct lock *lock) {
 	ASSERT (cond != NULL);
 	ASSERT (lock != NULL);
 
@@ -318,9 +318,9 @@ cond_broadcast (struct condition *cond, struct lock *lock) {
 		cond_signal (cond, lock);
 }
 
-bool condition_priority_less(const struct list_elem *a, const struct list_elem *b, void *aux UNUSED) {
+static bool condition_priority_less(const struct list_elem *a, const struct list_elem *b, void *aux UNUSED) {
 	struct semaphore_elem *sa = list_entry(a, struct semaphore_elem, elem);
 	struct semaphore_elem *sb = list_entry(b, struct semaphore_elem, elem);
 
-	return sa->priority < sb->priority;
+	return sa->priority > sb->priority;
 }

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -65,7 +65,6 @@ static struct thread *next_thread_to_run (void);
 static void init_thread (struct thread *, const char *name, int priority);
 static void do_schedule(int status);
 static bool wake_up_less (const struct list_elem *, const struct list_elem *, void *aux);
-static bool thread_priority_less(const struct list_elem *a, const struct list_elem *b, void *aux UNUSED);
 static void schedule (void);
 
 static tid_t allocate_tid (void);
@@ -363,7 +362,7 @@ thread_set_priority (int new_priority) {
 }
 
 /* thread priority가 더 높은 쪽을 꺼냄 */
-static bool thread_priority_less(const struct list_elem *a, const struct list_elem *b, void *aux UNUSED) {
+bool thread_priority_less(const struct list_elem *a, const struct list_elem *b, void *aux UNUSED) {
     struct thread *ta = list_entry(a, struct thread, elem);
     struct thread *tb = list_entry(b, struct thread, elem);
 

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -65,6 +65,7 @@ static struct thread *next_thread_to_run (void);
 static void init_thread (struct thread *, const char *name, int priority);
 static void do_schedule(int status);
 static bool wake_up_less (const struct list_elem *, const struct list_elem *, void *aux);
+static bool thread_priority_less(const struct list_elem *a, const struct list_elem *b, void *aux UNUSED);
 static void schedule (void);
 
 static tid_t allocate_tid (void);
@@ -362,15 +363,12 @@ thread_set_priority (int new_priority) {
 }
 
 /* thread priority가 더 높은 쪽을 꺼냄 */
-bool
-thread_priority_less(const struct list_elem *a, const struct list_elem *b, void *aux UNUSED)
-{
+static bool thread_priority_less(const struct list_elem *a, const struct list_elem *b, void *aux UNUSED) {
     struct thread *ta = list_entry(a, struct thread, elem);
     struct thread *tb = list_entry(b, struct thread, elem);
 
     return ta->priority > tb->priority;
 }
-
 
 /* 현재 스레드의 우선순위를 반환한다. */
 int

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -178,8 +178,7 @@ thread_print_stats (void) {
    실제 우선순위 스케줄링은 아직 구현되어 있지 않다.
    우선순위 스케줄링은 Problem 1-3의 목표다. */
 tid_t
-thread_create (const char *name, int priority,
-		thread_func *function, void *aux) {
+thread_create (const char *name, int priority,thread_func *function, void *aux) {
 	struct thread *t;
 	tid_t tid;
 
@@ -207,6 +206,10 @@ thread_create (const char *name, int priority,
 
 	/* 실행 큐에 추가한다. */
 	thread_unblock (t);
+
+	if (t->priority > thread_current()->priority) {
+		thread_yield();
+	}
 
 	return tid;
 }
@@ -278,7 +281,7 @@ thread_unblock (struct thread *t) {
 
 	old_level = intr_disable ();
 	ASSERT (t->status == THREAD_BLOCKED);
-	list_push_back (&ready_list, &t->elem);
+	list_insert_ordered(&ready_list, &t->elem, thread_priority_less, NULL);
 	t->status = THREAD_READY;
 	intr_set_level (old_level);
 }
@@ -340,7 +343,7 @@ thread_yield (void) {
 
 	old_level = intr_disable ();
 	if (curr != idle_thread)
-		list_push_back (&ready_list, &curr->elem);
+		list_insert_ordered(&ready_list, &curr->elem, thread_priority_less, NULL);
 	do_schedule (THREAD_READY);
 	intr_set_level (old_level);
 }
@@ -349,7 +352,25 @@ thread_yield (void) {
 void
 thread_set_priority (int new_priority) {
 	thread_current ()->priority = new_priority;
+
+	if (!list_empty(&ready_list)) {
+		struct thread *t = list_entry(list_front(&ready_list), struct thread, elem);
+		if (t->priority > thread_current()->priority) {
+			thread_yield();
+		}
+	}
 }
+
+/* thread priority가 더 높은 쪽을 꺼냄 */
+bool
+thread_priority_less(const struct list_elem *a, const struct list_elem *b, void *aux UNUSED)
+{
+    struct thread *ta = list_entry(a, struct thread, elem);
+    struct thread *tb = list_entry(b, struct thread, elem);
+
+    return ta->priority > tb->priority;
+}
+
 
 /* 현재 스레드의 우선순위를 반환한다. */
 int


### PR DESCRIPTION
## 변경 내용
- `sema_down()`에서 semaphore waiters를 우선순위 기준으로 정렬하도록 변경했습니다.
- `sema_up()`에서 가장 높은 우선순위 스레드를 먼저 깨우고, 현재 스레드보다 우선순위가 높으면 즉시 선점이 일어나도록 처리했습니다.
- `cond_wait()` / `cond_signal()`에서 condition waiters도 우선순위 순서로 관리되도록 구현했습니다.
- `thread_unblock()`, `thread_yield()`, `thread_create()`, `thread_set_priority()` 흐름을 정리해 ready list가 우선순위 기반으로 동작하도록 맞췄습니다.

## 테스트
| 테스트 | 결과 |
| --- | --- |
| `priority-sema` | PASS |
| `priority-condvar` | PASS |

## 리뷰 포인트
- 현재 condition waiter의 우선순위를 `cond_wait()` 시점에 저장하고 있어, 대기 중 priority donation이 발생하는 경우 최신 우선순위가 반영되지 않을 가능성이 있습니다.
- `ready_list`와 semaphore/condition waiters를 모두 정렬 기반으로 바꾼 만큼, 동일 우선순위 스레드에서 기존 FIFO 보장이 깨지지 않는지 추가 확인이 필요합니다.

## PR 체크리스트
- [x] 관련 테스트를 직접 돌렸습니다.
- [x] 테스트 결과를 적었습니다.
- [x] 남은 리스크(리뷰 포인트)가 있으면 적었습니다.
