### PR TITLE
[priority] 준비 큐 우선순위 정렬·선점 및 동순위 FIFO 유지

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,24 @@
+{
+  "editor.quickSuggestions": {
+    "other": true,
+    "comments": false,
+    "strings": false
+  },
+  "editor.suggestOnTriggerCharacters": true,
+  "editor.inlineSuggest.enabled": true,
+  "editor.tabCompletion": "on",
+  "editor.suggest.showFields": true,
+  "editor.suggest.showProperties": true,
+  "files.associations": {
+    "*.c": "c",
+    "*.h": "c"
+  },
+  "C_Cpp.intelliSenseEngine": "Tag Parser",
+  "C_Cpp.autocomplete": "Default",
+  "C_Cpp.default.compilerPath": "/usr/bin/gcc",
+  "clangd.onConfigChanged": "restart",
+  "clangd.fallbackFlags": [
+    "-xc",
+    "-std=gnu11"
+  ]
+}

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -123,7 +123,8 @@ void thread_print_stats (void);
 typedef void thread_func (void *aux);
 tid_t thread_create (const char *name, int priority, thread_func *, void *);
 
-void thread_sleep (int64_t);
+void thread_sleep (int64_t wakeup_tick);
+void thread_awake (int64_t current_tick);
 void thread_block (void);
 void thread_unblock (struct thread *);
 

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -65,6 +65,7 @@ static struct thread *next_thread_to_run (void);
 static void init_thread (struct thread *, const char *name, int priority);
 static void do_schedule(int status);
 static bool wake_up_less (const struct list_elem *, const struct list_elem *, void *aux);
+static bool cmp_priority (const struct list_elem *a, const struct list_elem *b, void *aux);
 static void schedule (void);
 
 static tid_t allocate_tid (void);
@@ -206,8 +207,10 @@ thread_create (const char *name, int priority,
 	t->tf.eflags = FLAG_IF;
 
 	/* 실행 큐에 추가한다. */
-	thread_unblock (t);
-
+	thread_unblock (t); 
+	if (t->priority > thread_current()->priority) {
+		thread_yield(); // ready_list는 이미 priority 순으로 정렬되어 있기 때문에 t는 ready_list의 맨 앞에 와 있고, t가 다음으로 실행
+	}
 	return tid;
 }
 
@@ -221,6 +224,7 @@ void thread_awake(int64_t now) {
 	 
 	list_pop_front(&sleep_list);
 	thread_unblock(t);
+	
 	}
 }
 
@@ -234,7 +238,6 @@ void thread_sleep(int64_t wakeup_tick) {
 	list_insert_ordered(&sleep_list, &curr->elem, wake_up_less, NULL);
 
 	thread_block();
-
 	intr_set_level(old_level);
 }
 
@@ -261,6 +264,7 @@ static bool wake_up_less (const struct list_elem *a, const struct list_elem *b, 
 
 	if (ta->wakeup_tick != tb->wakeup_tick)
 		return ta->wakeup_tick < tb->wakeup_tick;
+	return false;
 }
 
 /* 블록된 스레드 `T`를 실행 가능한 준비 상태로 바꾼다.
@@ -278,7 +282,7 @@ thread_unblock (struct thread *t) {
 
 	old_level = intr_disable ();
 	ASSERT (t->status == THREAD_BLOCKED);
-	list_push_back (&ready_list, &t->elem);
+	list_insert_ordered(&ready_list, &t->elem, cmp_priority, NULL); // priority가 높은 순으로 앞쪽으로 삽입
 	t->status = THREAD_READY;
 	intr_set_level (old_level);
 }
@@ -339,16 +343,34 @@ thread_yield (void) {
 	ASSERT (!intr_context ());
 
 	old_level = intr_disable ();
-	if (curr != idle_thread)
-		list_push_back (&ready_list, &curr->elem);
-	do_schedule (THREAD_READY);
-	intr_set_level (old_level);
+	if (curr != idle_thread) {
+		list_insert_ordered(&ready_list, &curr->elem, cmp_priority, NULL); // priority가 높은 순으로 앞쪽으로 삽입;
+		do_schedule (THREAD_READY);
+		intr_set_level (old_level);
+	}
+}
+
+/* list elem a의 priority가 b의 priority 보다 높은지 확인한다.  */
+bool cmp_priority(const struct list_elem *a, const struct list_elem *b, void *aux) {
+	struct thread *ta = list_entry(a, struct thread, elem);
+	struct thread *tb = list_entry(b, struct thread, elem);
+
+	return ta->priority > tb->priority;
 }
 
 /* 현재 스레드의 우선순위를 `NEW_PRIORITY`로 설정한다. */
 void
 thread_set_priority (int new_priority) {
 	thread_current ()->priority = new_priority;
+	
+	if (!list_empty(&ready_list)) {  // 여기부터 priority_change test
+		struct list_elem *elem = list_begin(&ready_list);
+		struct thread *head = list_entry(elem, struct thread, elem);
+		
+		if (head->priority > new_priority) { 
+		thread_yield();
+		}
+	}	
 }
 
 /* 현재 스레드의 우선순위를 반환한다. */


### PR DESCRIPTION
## 변경 내용

- **우선순위**: `ready_list`를 `list_insert_ordered` + `cmp_priority`로 유지, `thread_unblock` / `thread_yield`에서 우선순위 순 삽입, 더 높은 우선순위 스레드 생성 시 및 현재 스레드 우선순위 하향 시 `thread_yield`로 선점/양보.

**테스트**

| 테스트 | 결과 |
| --- | --- |
| `priority-preempt` | PASS |
| `priority-change` | PASS |
| `priority-fifo` | PASS |

**## 리뷰 포인트**

- 동일 `wakeup_tick`에서 슬립 리스트 정렬/깨우기 순서가 테스트·스펙과 맞는지.
- 인터럽트 컨텍스트 vs 일반 컨텍스트에서 `thread_yield`/`thread_block` 호출 경로가 안전한지.
- `cmp_priority`에서 동순위일 때 FIFO가 유지되는지(`list_insert_ordered` 동작과 일치하는지).
- 아직 **priority donation / sema / condvar** 구현 담당과 충돌하지 않는지
**## PR 체크리스트**

- [x] 관련 테스트를 직접 돌렸습니다.
- [x] 테스트 결과를 적었습니다.
- [x] 남은 리스크(리뷰 포인트)가 있으면 적었습니다.