### PR TITLE
[priority] 우선순위 기반 선점과 semaphore/condvar 대기열 정렬 구현

### DIFF
--- a/pintos/tests/threads/priority-condvar.c
+++ b/pintos/tests/threads/priority-condvar.c
@@ -47,6 +47,7 @@ priority_condvar_thread (void *aux UNUSED)
 {
   msg ("Thread %s starting.", thread_name ());
   lock_acquire (&lock);
+  cond_wait (&condition, &lock);
   msg ("Thread %s woke up.", thread_name ());
   lock_release (&lock);
 }

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -67,7 +67,7 @@ sema_down (struct semaphore *sema) {
 
 	old_level = intr_disable ();
 	while (sema->value == 0) {
-		list_insert_ordered(&sema->waiters, &thread_current()->elem, cmp_sema_priority, NULL);
+		list_insert_ordered(&sema->waiters, &thread_current()->elem, cmp_priority, NULL);
 		thread_block ();
 	}
 	sema->value--;


### PR DESCRIPTION
## 변경 내용
- `thread_create()`에서 더 높은 우선순위의 스레드가 생성되면 즉시 `thread_yield()` 하도록 반영했습니다.
- `thread_set_priority()`에서 현재 스레드의 우선순위를 낮춘 뒤, ready list의 최고 우선순위 스레드가 더 높으면 즉시 양보하도록 처리했습니다.
- `ready_list`를 우선순위 기준으로 정렬해 `priority-preempt`, `priority-change`, `priority-fifo`, `alarm-priority` 요구사항을 만족하도록 맞췄습니다.
- `sema_down()`/`sema_up()`에서 semaphore waiter를 우선순위 기준으로 관리해 `priority-sema`를 통과하도록 수정했습니다.
- `cond_wait()`/`cond_signal()`에서 condition waiter를 우선순위 기준으로 관리해 `priority-condvar`를 통과하도록 수정했습니다.
- 로컬 `priority-condvar` 테스트 파일이 `cond_wait()`를 타지 않던 문제를 바로잡아 실제 condvar 경로를 검증하도록 복구했습니다.

## 테스트

| 테스트 | 결과 |
| --- | --- |
| `priority-preempt` | PASS |
| `priority-change` | PASS |
| `priority-fifo` | PASS |
| `alarm-priority` | PASS |
| `priority-sema` | PASS |
| `priority-condvar` | PASS |

## 리뷰 포인트
- `cond_wait()`에서 waiter의 priority를 대기 진입 시점 값으로 저장하고 있어, 대기 중 priority donation이 발생하는 경우 최신 priority가 바로 반영되지 않을 수 있습니다.
- `priority-condvar.c`는 로컬 브랜치에서 `cond_wait()` 호출이 빠진 변형이 있었고, 이번에 원래 의도대로 복구했습니다. 머지 시 테스트 파일이 다시 잘못 섞이지 않도록 확인이 필요합니다.

## PR 체크리스트
- [x] 관련 테스트를 직접 돌렸습니다.
- [x] 테스트 결과를 적었습니다.
- [x] 남은 리스크(리뷰 포인트)가 있으면 적었습니다.
