### PR TITLE
[priority] 우선순위 스케줄링과 priority donation 구현

### DIFF
--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -87,7 +87,11 @@ struct thread {
 	tid_t tid;                          /* 스레드 식별자. */
 	enum thread_status status;          /* 스레드 상태. */
 	char name[16];                      /* 이름(디버깅용). */
-	int priority;                       /* 우선순위. */
+	int priority;						// 현재 effective priority
+	int init_priority;					// 원래/base priority
+	struct lock *wait_on_lock;			// 현재 기다리는 lock
+	struct list donations;				// 나에게 priority를 준 donor 목록(기부자 명단)
+	struct list_elem donation_elem;		// 내가 다른 thread의 donations에 들어갈 때 사용
 
 	/* 스레드가 깨어나야 하는 절대 tick 시각. */
 	int64_t wakeup_tick;

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -115,6 +115,7 @@ sema_up (struct semaphore *sema) {
 
 	struct thread *cur = thread_current();
 	if (!list_empty (&sema->waiters)) {
+		list_sort(&sema->waiters, cmp_priority, NULL);
 		struct thread *waiter = list_entry(list_pop_front(&sema->waiters),
 										   struct thread, elem);
 		thread_unblock(waiter);

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -43,6 +43,7 @@
 
 static bool wake_up_less(const struct list_elem *, const struct list_elem *, void *aux);
 static bool cmp_sema_priority(const struct list_elem *a, const struct list_elem *b, void *aux UNUSED);
+static bool cmp_donation_priority(const struct list_elem *a, const struct list_elem *b, void *aux UNUSED);
 
 void
 sema_init (struct semaphore *sema, unsigned value) {
@@ -133,6 +134,13 @@ sema_up (struct semaphore *sema) {
 	}
 }
 
+static bool cmp_donation_priority(const struct list_elem *a, const struct list_elem *b, void *aux UNUSED) {
+	struct thread *ta = list_entry(a, struct thread, donation_elem);
+	struct thread *tb = list_entry(b, struct thread, donation_elem);
+
+	return ta->priority > tb->priority;
+}
+
 static void sema_test_helper (void *sema_);
 
 /* 두 스레드가 번갈아 제어권을 주고받도록 만들어 보는
@@ -198,8 +206,16 @@ lock_acquire (struct lock *lock) {
 	ASSERT (!intr_context ());
 	ASSERT (!lock_held_by_current_thread (lock));
 
+	if (lock->holder != NULL) {
+		thread_current()->wait_on_lock = lock;
+		list_insert_ordered(&lock->holder->donations, &thread_current()->donation_elem, cmp_donation_priority, NULL);
+		if (thread_current()->priority > lock->holder->priority) {
+			lock->holder->priority = thread_current()->priority;
+		}
+	}
 	sema_down (&lock->semaphore);
-	lock->holder = thread_current ();
+	thread_current()->wait_on_lock = NULL;
+	lock->holder = thread_current();
 }
 
 /* `LOCK` 획득을 시도하고, 성공하면 true 아니면 false를 반환한다.
@@ -228,6 +244,30 @@ lock_release (struct lock *lock) {
 	ASSERT (lock != NULL);
 	ASSERT (lock_held_by_current_thread (lock));
 
+	struct thread *cur = thread_current();
+	struct list_elem *e = list_begin(&cur->donations);
+
+	while (e != list_end(&cur->donations)) {
+		struct thread *donor = list_entry(e, struct thread, donation_elem);
+		struct list_elem *next = list_next(e);
+
+		if (donor->wait_on_lock == lock) {
+			list_remove(e);
+		}
+		e = next;
+	}
+
+	// donor를 지운 뒤 priority를 어떻게 다시 계산할지
+	cur->priority = cur->init_priority;
+	e = list_begin(&cur->donations);
+
+	while(e != list_end(&cur->donations)) {
+		struct thread *donor = list_entry(e, struct thread, donation_elem);
+		if (donor->priority > cur->priority) {
+			cur->priority = donor->priority;
+		}
+		e = list_next(e);
+	}
 	lock->holder = NULL;
 	sema_up (&lock->semaphore);
 }

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -210,13 +210,28 @@ lock_acquire (struct lock *lock) {
 	if (lock->holder != NULL) {
 		thread_current()->wait_on_lock = lock;
 		list_insert_ordered(&lock->holder->donations, &thread_current()->donation_elem, cmp_donation_priority, NULL);
-		if (thread_current()->priority > lock->holder->priority) {
-			lock->holder->priority = thread_current()->priority;
-		}
+		give_donation(lock);
 	}
 	sema_down (&lock->semaphore);
 	thread_current()->wait_on_lock = NULL;
 	lock->holder = thread_current();
+}
+
+void give_donation(struct lock *lock) {
+	int depth = 0;
+	int priority = thread_current()->priority;
+	struct lock *current_lock = lock;
+	
+	while(current_lock != NULL && current_lock->holder != NULL && depth < 8) {
+		struct thread *hold = current_lock->holder;
+		
+		if (hold->priority < priority)
+		{
+			hold->priority = priority;
+		}
+		current_lock = hold->wait_on_lock;
+		depth ++;
+	}
 }
 
 /* `LOCK` 획득을 시도하고, 성공하면 true 아니면 false를 반환한다.

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -382,12 +382,18 @@ void thread_yield(void)
 /* 현재 스레드의 우선순위를 `NEW_PRIORITY`로 설정한다. */
 void thread_set_priority(int new_priority)
 {
-	thread_current()->priority = new_priority;
+	struct thread *cur = thread_current();
+	cur->init_priority = new_priority;
+
+	if (list_empty(&cur->donations)) {
+		cur->priority = new_priority;
+	}
+
 	if (!list_empty(&ready_list))
 	{
 		struct list_elem *head_elem = list_begin(&ready_list);
 		struct thread *head_thread = list_entry(head_elem, struct thread, elem);
-		if (thread_current()->priority < head_thread->priority)
+		if (cur->priority < head_thread->priority)
 		{
 			thread_yield();
 		}
@@ -486,6 +492,8 @@ init_thread(struct thread *t, const char *name, int priority)
 	strlcpy(t->name, name, sizeof t->name);
 	t->tf.rsp = (uint64_t)t + PGSIZE - sizeof(void *);
 	t->priority = priority;
+	t->init_priority = priority;
+	list_init(&t->donations);
 	t->magic = THREAD_MAGIC;
 }
 


### PR DESCRIPTION


## 변경 내용

- ready list를 우선순위 기준으로 정렬해 높은 우선순위 스레드가 먼저 실행되도록 구현했습니다.
- `thread_set_priority()`가 base priority와 effective priority를 분리해 처리하도록 수정했습니다.
- 세마포어와 조건변수 대기열에서 우선순위가 높은 스레드를 먼저 깨우도록 반영했습니다.
- lock 획득/해제 시 priority donation과 donation 회수를 처리하도록 구현했습니다.
- 여러 donor가 동시에 donation하는 경우를 처리하도록 `donations` 리스트와 priority 재계산 로직을 추가했습니다.

## 테스트

| 테스트 | 결과 |
| --- | --- |
| `alarm-zero` | PASS |
| `alarm-negative` | PASS |
| `alarm-single` | PASS |
| `alarm-multiple` | PASS |
| `alarm-simultaneous` | PASS |
| `priority-preempt` | PASS |
| `priority-change` | PASS |
| `priority-fifo` | PASS |
| `alarm-priority` | PASS |
| `priority-sema` | PASS |
| `priority-condvar` | PASS |
| `priority-donate-one` | PASS |
| `priority-donate-multiple` | PASS |
| `priority-donate-multiple2` | PASS |
| `priority-donate-nest` | FAIL |
| `priority-donate-sema` | PASS |
| `priority-donate-lower` | PASS |

## 리뷰 포인트

- 현재 `priority-donate-nest`가 실패합니다.
- 기대값은 low thread priority가 33까지 올라가야 하는데, 실제로는 32까지만 반영되고 있습니다.
- 즉, 중첩 donation 전파가 완전히 처리되지 않은 상태로 보입니다.
- `wait_on_lock`을 따라 holder의 holder까지 donation을 재귀적 또는 반복적으로 전파하는 로직이 필요한지 중점적으로 보면 좋겠습니다.

## PR 체크리스트

- [x] 관련 테스트를 직접 돌렸습니다.
- [x] 테스트 결과를 적었습니다.
- [x] 남은 리스크(리뷰 포인트)가 있으면 적었습니다.
