### PR TITLE
[priority] priority donation(one, lower, nest) 구현

### DIFF
--- a/pintos/.vscode/pintos-test-history.json
+++ b/pintos/.vscode/pintos-test-history.json
@@ -1,0 +1,139 @@
+{
+  "threads": {
+    "tests/threads/alarm-single": {
+      "count": 1,
+      "last_used": 1777373402.375,
+      "last_action": "run"
+    },
+    "tests/threads/alarm-multiple": {
+      "count": 1,
+      "last_used": 1777373402.375,
+      "last_action": "run"
+    },
+    "tests/threads/alarm-simultaneous": {
+      "count": 1,
+      "last_used": 1777373402.375,
+      "last_action": "run"
+    },
+    "tests/threads/alarm-priority": {
+      "count": 1,
+      "last_used": 1777373402.375,
+      "last_action": "run"
+    },
+    "tests/threads/alarm-zero": {
+      "count": 1,
+      "last_used": 1777373402.375,
+      "last_action": "run"
+    },
+    "tests/threads/alarm-negative": {
+      "count": 1,
+      "last_used": 1777373402.375,
+      "last_action": "run"
+    },
+    "tests/threads/priority-change": {
+      "count": 1,
+      "last_used": 1777373402.375,
+      "last_action": "run"
+    },
+    "tests/threads/priority-donate-one": {
+      "count": 2,
+      "last_used": 1777373403.708,
+      "last_action": "run"
+    },
+    "tests/threads/priority-donate-multiple": {
+      "count": 1,
+      "last_used": 1777373402.375,
+      "last_action": "run"
+    },
+    "tests/threads/priority-donate-multiple2": {
+      "count": 2,
+      "last_used": 1777373403.708,
+      "last_action": "run"
+    },
+    "tests/threads/priority-donate-nest": {
+      "count": 1,
+      "last_used": 1777373402.375,
+      "last_action": "run"
+    },
+    "tests/threads/priority-donate-sema": {
+      "count": 2,
+      "last_used": 1777373403.708,
+      "last_action": "run"
+    },
+    "tests/threads/priority-donate-lower": {
+      "count": 2,
+      "last_used": 1777373403.708,
+      "last_action": "run"
+    },
+    "tests/threads/priority-fifo": {
+      "count": 1,
+      "last_used": 1777373402.375,
+      "last_action": "run"
+    },
+    "tests/threads/priority-preempt": {
+      "count": 1,
+      "last_used": 1777373402.375,
+      "last_action": "run"
+    },
+    "tests/threads/priority-sema": {
+      "count": 1,
+      "last_used": 1777373402.375,
+      "last_action": "run"
+    },
+    "tests/threads/priority-condvar": {
+      "count": 1,
+      "last_used": 1777373402.375,
+      "last_action": "run"
+    },
+    "tests/threads/priority-donate-chain": {
+      "count": 1,
+      "last_used": 1777373402.375,
+      "last_action": "run"
+    },
+    "tests/threads/mlfqs/mlfqs-load-1": {
+      "count": 1,
+      "last_used": 1777373402.375,
+      "last_action": "run"
+    },
+    "tests/threads/mlfqs/mlfqs-load-60": {
+      "count": 1,
+      "last_used": 1777373402.375,
+      "last_action": "run"
+    },
+    "tests/threads/mlfqs/mlfqs-load-avg": {
+      "count": 1,
+      "last_used": 1777373402.375,
+      "last_action": "run"
+    },
+    "tests/threads/mlfqs/mlfqs-recent-1": {
+      "count": 1,
+      "last_used": 1777373402.375,
+      "last_action": "run"
+    },
+    "tests/threads/mlfqs/mlfqs-fair-2": {
+      "count": 1,
+      "last_used": 1777373402.375,
+      "last_action": "run"
+    },
+    "tests/threads/mlfqs/mlfqs-fair-20": {
+      "count": 1,
+      "last_used": 1777373402.375,
+      "last_action": "run"
+    },
+    "tests/threads/mlfqs/mlfqs-nice-2": {
+      "count": 1,
+      "last_used": 1777373402.375,
+      "last_action": "run"
+    },
+    "tests/threads/mlfqs/mlfqs-nice-10": {
+      "count": 1,
+      "last_used": 1777373402.375,
+      "last_action": "run"
+    },
+    "tests/threads/mlfqs/mlfqs-block": {
+      "count": 1,
+      "last_used": 1777373402.375,
+      "last_action": "run"
+    }
+  }
+}

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -92,6 +92,7 @@ struct  thread {
 
 	struct lock *wait_on_lock;          /* 현재 스레드에서 기다리고 있는 lock */
 	struct list donations;              /* 우선순위 기부해준 리스트 목록 */
+	struct list_elem donation_elem;    /* 타 스레드 donation 리스트의 원소 */
 
 	/* 스레드가 깨어나야 하는 절대 tick 시각. */
 	int64_t wakeup_tick;

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -82,12 +82,13 @@ typedef int tid_t;
  * 원소가 될 수도 있다. 이 두 용도가 동시에 겹치지 않는 이유는
  * 준비 상태의 스레드만 실행 큐에 있고, 블록 상태의 스레드만
  * 세마포어 대기 리스트에 있기 때문이다. */
-struct thread {
+struct  thread {
 	/* `thread.c`가 관리한다. */
 	tid_t tid;                          /* 스레드 식별자. */
 	enum thread_status status;          /* 스레드 상태. */
 	char name[16];                      /* 이름(디버깅용). */
 	int priority;                       /* 우선순위. */
+	int origin_priority;                /* donate 받기 전 우선순위 */
 
 	/* 스레드가 깨어나야 하는 절대 tick 시각. */
 	int64_t wakeup_tick;

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -90,7 +90,8 @@ struct  thread {
 	int priority;                       /* 우선순위. */
 	int origin_priority;                /* donate 받기 전 우선순위 */
 
-	struct lock *wait_on_lock;                  /* 현재 스레드에서 기다리고 있는 lock */
+	struct lock *wait_on_lock;          /* 현재 스레드에서 기다리고 있는 lock */
+	struct list donations;              /* 우선순위 기부해준 리스트 목록 */
 
 	/* 스레드가 깨어나야 하는 절대 tick 시각. */
 	int64_t wakeup_tick;

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -90,6 +90,8 @@ struct  thread {
 	int priority;                       /* 우선순위. */
 	int origin_priority;                /* donate 받기 전 우선순위 */
 
+	struct lock *wait_on_lock;                  /* 현재 스레드에서 기다리고 있는 lock */
+
 	/* 스레드가 깨어나야 하는 절대 tick 시각. */
 	int64_t wakeup_tick;
 

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -284,6 +284,13 @@ struct semaphore_elem {
 	int priority;
 };
 
+/* donation 요소 하나 */
+struct donoation {
+    struct list_elem elem;       /* 리스트 원소 */
+    struct thread *donor;        /* 스레드 */
+    struct lock *lock;           /* 기다리고 있는 락 */
+};
+
 /* 조건 변수 `COND`를 초기화한다. 조건 변수는 한 코드 조각이
    조건을 신호로 보내고, 협력하는 다른 코드가 그 신호를 받아
    동작하도록 해 준다. */
@@ -370,11 +377,16 @@ cond_broadcast (struct condition *cond, struct lock *lock) {
 
 /* 우선순위 기부 */
 static void donate_priority(struct thread *current, struct thread *holder) {
-	holder->origin_priority = holder->priority;
-	holder->priority = current->priority;
+	if (holder->priority < current->priority) {
+		holder->priority = current->priority;
+	}
+	//list_push_back(&holder->donations, &current->elem);
 }
 
 /* 우선순위 기부 제거 */
 static void remove_donations(struct lock *lock) {
-	lock->holder->priority = lock->holder->origin_priority;
+	if (!list_empty(&lock->semaphore.waiters)) {
+		lock->holder->priority = lock->holder->origin_priority;
+	}
+	//list_pop_front(&lock->holder->donations);
 }

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -44,7 +44,8 @@
 static bool wake_up_less(const struct list_elem *, const struct list_elem *, void *aux);
 static bool cmp_sema_priority(const struct list_elem *a, const struct list_elem *b, void *aux UNUSED);
 static void donate_priority(struct thread *current);
-static void remove_donations(struct lock *lock);
+static void remove_donations(struct thread *current, struct lock *lock);
+static void refresh_priority(struct thread *current);
 static bool cmp_donation_priority(const struct list_elem *a, const struct list_elem *b, void *aux UNUSED);
 
 void
@@ -204,11 +205,9 @@ lock_acquire (struct lock *lock) {
 	struct thread *current = thread_current();
 	struct thread *holder = lock->holder;
 	if (lock->holder != NULL) {
+		current->wait_on_lock = lock;
 		list_insert_ordered(&holder->donations, &current->donation_elem, cmp_donation_priority, NULL);
-
-		if (holder->priority < current->priority) {
-			donate_priority(current);
-		}
+		donate_priority(current);
 	}
 
 	sema_down(&lock->semaphore);   // 요청 스레드 블락(여기에서 잠듦)
@@ -242,7 +241,8 @@ lock_release (struct lock *lock) {
 	ASSERT (lock != NULL);
 	ASSERT (lock_held_by_current_thread (lock));
 
-	remove_donations(lock);
+	remove_donations(thread_current(), lock);
+	refresh_priority(thread_current());
 	lock->holder = NULL;
 
 	sema_up (&lock->semaphore);
@@ -359,29 +359,50 @@ cond_broadcast (struct condition *cond, struct lock *lock) {
 /* 우선순위 기부 */
 static void donate_priority(struct thread *current) {
 	int depth = 0;
-	struct lock *lock = current->wait_on_lock;
-	struct thread *holder = lock->holder;
 
-	while (lock != NULL && depth < 8) {
+	while (current->wait_on_lock != NULL && depth < 8) {
+		struct thread *holder = current->wait_on_lock->holder;
+
 		if (holder == NULL) {
 			break;
 		}
 
-		if (holder->priority < current->priority) {
-			holder->priority = current->priority;
-			current = holder;
-			depth++;
-		}
-		else {
+		if (holder->priority >= current->priority) {
 			break;
 		}
+
+		holder->priority = current->priority;
+		current = holder;
+		depth++;
 	}
 }
 
 /* 우선순위 기부 제거 */
-static void remove_donations(struct lock *lock) {
-	if (!list_empty(&lock->semaphore.waiters)) {
-		lock->holder->priority = lock->holder->origin_priority;
+static void remove_donations(struct thread *current, struct lock *lock) {
+	struct list_elem *le = list_begin(&current->donations);
+
+
+	while (le != list_end(&current->donations)) {
+		struct thread *donor = list_entry(le, struct thread, donation_elem);
+		struct list_elem *next = list_next(le);
+
+		if (donor->wait_on_lock == lock) {
+			list_remove(le);
+		}
+		le = next;
 	}
-	//list_pop_front(&lock->holder->donations);
+}
+
+/* 우선순위 초기화 */
+static void refresh_priority(struct thread *current) {
+	current->priority = current->origin_priority;
+
+	if (!list_empty(&current->donations)) {
+		list_sort(&current->donations, cmp_donation_priority, NULL);
+		struct thread *donor = list_entry(list_front(&current->donations), struct thread, donation_elem);
+
+		if (current->priority < donor->priority) {
+			current->priority = donor->priority;
+		}
+	}
 }

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -118,6 +118,7 @@ sema_up (struct semaphore *sema) {
 
 	struct thread *cur = thread_current();
 	if (!list_empty (&sema->waiters)) {
+		list_sort(&sema->waiters, cmp_priority, NULL);
 		struct thread *waiter = list_entry(list_pop_front(&sema->waiters),
 										   struct thread, elem);
 		thread_unblock(waiter);
@@ -380,7 +381,6 @@ static void donate_priority(struct thread *current) {
 /* 우선순위 기부 제거 */
 static void remove_donations(struct thread *current, struct lock *lock) {
 	struct list_elem *le = list_begin(&current->donations);
-
 
 	while (le != list_end(&current->donations)) {
 		struct thread *donor = list_entry(le, struct thread, donation_elem);

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -43,8 +43,9 @@
 
 static bool wake_up_less(const struct list_elem *, const struct list_elem *, void *aux);
 static bool cmp_sema_priority(const struct list_elem *a, const struct list_elem *b, void *aux UNUSED);
-static void donate_priority(struct thread *current, struct thread *holder);
+static void donate_priority(struct thread *current);
 static void remove_donations(struct lock *lock);
+static bool cmp_donation_priority(const struct list_elem *a, const struct list_elem *b, void *aux UNUSED);
 
 void
 sema_init (struct semaphore *sema, unsigned value) {
@@ -203,10 +204,10 @@ lock_acquire (struct lock *lock) {
 	struct thread *current = thread_current();
 	struct thread *holder = lock->holder;
 	if (lock->holder != NULL) {
-		current->wait_on_lock = lock;   // 현재 스레드가 락을 잡고 있다고 기록
+		list_insert_ordered(&holder->donations, &current->donation_elem, cmp_donation_priority, NULL);
 
 		if (holder->priority < current->priority) {
-			donate_priority(current, holder);
+			donate_priority(current);
 		}
 	}
 
@@ -238,14 +239,6 @@ lock_try_acquire (struct lock *lock) {
    해제하려는 시도도 의미가 없다. */
 void
 lock_release (struct lock *lock) {
-
-	/*
-		1. lock holder를 비움
-		2. 이 lock 때문에 받은 기부 제거
-		3. 우선순위 재계산
-		4. sema_up()으로 대기자 하나 깨움
-	*/
-
 	ASSERT (lock != NULL);
 	ASSERT (lock_held_by_current_thread (lock));
 
@@ -272,13 +265,6 @@ struct semaphore_elem {
 	int priority;
 };
 
-/* donation 요소 하나 */
-struct donoation {
-    struct list_elem elem;       /* 리스트 원소 */
-    struct thread *donor;        /* 스레드 */
-    struct lock *lock;           /* 기다리고 있는 락 */
-};
-
 /* 조건 변수 `COND`를 초기화한다. 조건 변수는 한 코드 조각이
    조건을 신호로 보내고, 협력하는 다른 코드가 그 신호를 받아
    동작하도록 해 준다. */
@@ -295,7 +281,14 @@ bool cmp_sema_priority(const struct list_elem *a, const struct list_elem *b, voi
 	struct semaphore_elem *sb = list_entry(b, struct semaphore_elem, elem);
 
 	return sa->priority > sb->priority;
+}
 
+/* donation 정렬 비교함수 */
+static bool cmp_donation_priority(const struct list_elem *a, const struct list_elem *b, void *aux UNUSED) {
+	struct thread *da = list_entry(a, struct thread, donation_elem);
+	struct thread *db = list_entry(b, struct thread, donation_elem);
+
+	return da->priority > db->priority;
 }
 
 	/* `LOCK`를 원자적으로 해제하고, 다른 코드가 `COND`를 신호할 때까지
@@ -364,23 +357,24 @@ cond_broadcast (struct condition *cond, struct lock *lock) {
 }
 
 /* 우선순위 기부 */
-static void donate_priority(struct thread *current, struct thread *holder) {
-	int donated_priority = current->priority;
-	struct thread *lock = current->wait_on_lock;
+static void donate_priority(struct thread *current) {
+	int depth = 0;
+	struct lock *lock = current->wait_on_lock;
+	struct thread *holder = lock->holder;
 
-	while (lock != NULL) {
+	while (lock != NULL && depth < 8) {
 		if (holder == NULL) {
 			break;
 		}
 
 		if (holder->priority < current->priority) {
 			holder->priority = current->priority;
+			current = holder;
+			depth++;
 		}
 		else {
 			break;
 		}
-
-		lock = holder->wait_on_lock;
 	}
 }
 

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -43,6 +43,7 @@
 
 static bool wake_up_less(const struct list_elem *, const struct list_elem *, void *aux);
 static bool cmp_sema_priority(const struct list_elem *a, const struct list_elem *b, void *aux UNUSED);
+static void donate_priority(struct thread *current, struct thread *holder);
 
 void
 sema_init (struct semaphore *sema, unsigned value) {
@@ -208,17 +209,21 @@ lock_acquire (struct lock *lock) {
 
 	ASSERT (lock != NULL);
 	ASSERT (!intr_context ());
+	ASSERT (!lock_held_by_current_thread (lock));
 
+	struct thread *current = thread_current();
 	struct thread *holder = lock->holder;
-	if (!lock_held_by_current_thread (lock)) {
-		if (holder->priority < thread_current()->priority) {
-			holder->priority = thread_current()->priority;
+	if (lock->holder != NULL) {
+		current->wait_on_lock = lock;   // 현재 스레드가 락을 잡고 있다고 기록
 
+		if (holder->priority < current->priority) {
+			donate_priority(current, holder);
 		}
 	}
 
-	sema_down (&lock->semaphore);
-	lock->holder = thread_current ();
+	sema_down(&lock->semaphore);   // 요청 스레드 블락(여기에서 잠듦)
+	current->wait_on_lock = NULL;  // 현재 스레드 끝나서 락에서 나감
+	lock->holder = current;        // 현재 스레드가 락을 잡음
 }
 
 /* `LOCK` 획득을 시도하고, 성공하면 true 아니면 false를 반환한다.
@@ -350,4 +355,9 @@ cond_broadcast (struct condition *cond, struct lock *lock) {
 
 	while (!list_empty (&cond->waiters))
 		cond_signal (cond, lock);
+}
+
+static void donate_priority(struct thread *current, struct thread *holder) {
+	holder->origin_priority = holder->priority;
+	holder->priority = current->priority;
 }

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -174,9 +174,28 @@ lock_init (struct lock *lock) {
    하면 인터럽트가 다시 켜진다. */
 void
 lock_acquire (struct lock *lock) {
+
+	/*
+		* lock 요청
+		* lock이 이미 잡혀 있으면 holder 확인
+		* 요청한 스레드와 holder의 우선순위 비교
+		* 요청한 스레드가 더 높으면 holder에게 우선순위 기부
+		* 요청한 스레드는 blocked
+		* holder가 높아진 우선순위로 먼저 실행됨
+		* holder가 lock release
+		* 요청한 스레드가 깨어나 lock 획득
+	*/
+
 	ASSERT (lock != NULL);
 	ASSERT (!intr_context ());
-	ASSERT (!lock_held_by_current_thread (lock));
+
+	struct thread *holder = lock->holder;
+	if (!lock_held_by_current_thread (lock)) {
+		if (holder->priority < thread_current()->priority) {
+			holder->priority = thread_current()->priority;
+
+		}
+	}
 
 	sema_down (&lock->semaphore);
 	lock->holder = thread_current ();
@@ -226,6 +245,7 @@ lock_held_by_current_thread (const struct lock *lock) {
 struct semaphore_elem {
 	struct list_elem elem;              /* 리스트 원소. */
 	struct semaphore semaphore;         /* 해당 세마포어. */
+	int priority;
 };
 
 /* 조건 변수 `COND`를 초기화한다. 조건 변수는 한 코드 조각이

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -44,6 +44,7 @@
 static bool wake_up_less(const struct list_elem *, const struct list_elem *, void *aux);
 static bool cmp_sema_priority(const struct list_elem *a, const struct list_elem *b, void *aux UNUSED);
 static void donate_priority(struct thread *current, struct thread *holder);
+static void remove_donations(struct lock *lock);
 
 void
 sema_init (struct semaphore *sema, unsigned value) {
@@ -249,10 +250,20 @@ lock_try_acquire (struct lock *lock) {
    해제하려는 시도도 의미가 없다. */
 void
 lock_release (struct lock *lock) {
+
+	/*
+		1. lock holder를 비움
+		2. 이 lock 때문에 받은 기부 제거
+		3. 우선순위 재계산
+		4. sema_up()으로 대기자 하나 깨움
+	*/
+
 	ASSERT (lock != NULL);
 	ASSERT (lock_held_by_current_thread (lock));
 
+	remove_donations(lock);
 	lock->holder = NULL;
+
 	sema_up (&lock->semaphore);
 }
 
@@ -357,7 +368,13 @@ cond_broadcast (struct condition *cond, struct lock *lock) {
 		cond_signal (cond, lock);
 }
 
+/* 우선순위 기부 */
 static void donate_priority(struct thread *current, struct thread *holder) {
 	holder->origin_priority = holder->priority;
 	holder->priority = current->priority;
+}
+
+/* 우선순위 기부 제거 */
+static void remove_donations(struct lock *lock) {
+	lock->holder->priority = lock->holder->origin_priority;
 }

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -196,18 +196,6 @@ lock_init (struct lock *lock) {
    하면 인터럽트가 다시 켜진다. */
 void
 lock_acquire (struct lock *lock) {
-
-	/*
-		* lock 요청
-		* lock이 이미 잡혀 있으면 holder 확인
-		* 요청한 스레드와 holder의 우선순위 비교
-		* 요청한 스레드가 더 높으면 holder에게 우선순위 기부
-		* 요청한 스레드는 blocked
-		* holder가 높아진 우선순위로 먼저 실행됨
-		* holder가 lock release
-		* 요청한 스레드가 깨어나 lock 획득
-	*/
-
 	ASSERT (lock != NULL);
 	ASSERT (!intr_context ());
 	ASSERT (!lock_held_by_current_thread (lock));
@@ -377,10 +365,23 @@ cond_broadcast (struct condition *cond, struct lock *lock) {
 
 /* 우선순위 기부 */
 static void donate_priority(struct thread *current, struct thread *holder) {
-	if (holder->priority < current->priority) {
-		holder->priority = current->priority;
+	int donated_priority = current->priority;
+	struct thread *lock = current->wait_on_lock;
+
+	while (lock != NULL) {
+		if (holder == NULL) {
+			break;
+		}
+
+		if (holder->priority < current->priority) {
+			holder->priority = current->priority;
+		}
+		else {
+			break;
+		}
+
+		lock = holder->wait_on_lock;
 	}
-	//list_push_back(&holder->donations, &current->elem);
 }
 
 /* 우선순위 기부 제거 */

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -191,8 +191,6 @@ tid_t thread_create(const char *name, int priority,
 
 	/* 스레드를 초기화한다. */
 	init_thread(t, name, priority);
-	t->origin_priority = priority;
-	t->wait_on_lock = false;
 	tid = t->tid = allocate_tid();
 
 	/* 스케줄되면 `kernel_thread`를 호출하게 한다.
@@ -488,6 +486,8 @@ init_thread(struct thread *t, const char *name, int priority)
 	strlcpy(t->name, name, sizeof t->name);
 	t->tf.rsp = (uint64_t)t + PGSIZE - sizeof(void *);
 	t->priority = priority;
+	t->origin_priority = priority;
+	t->wait_on_lock = NULL;
 	t->magic = THREAD_MAGIC;
 }
 

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -191,6 +191,8 @@ tid_t thread_create(const char *name, int priority,
 
 	/* 스레드를 초기화한다. */
 	init_thread(t, name, priority);
+	t->origin_priority = priority;
+	t->wait_on_lock = false;
 	tid = t->tid = allocate_tid();
 
 	/* 스케줄되면 `kernel_thread`를 호출하게 한다.

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -192,6 +192,7 @@ thread_create (const char *name, int priority,
 
 	/* 스레드를 초기화한다. */
 	init_thread (t, name, priority);
+	t->origin_priority = priority;
 	tid = t->tid = allocate_tid ();
 
 	/* 스케줄되면 `kernel_thread`를 호출하게 한다.

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -382,12 +382,20 @@ void thread_yield(void)
 /* 현재 스레드의 우선순위를 `NEW_PRIORITY`로 설정한다. */
 void thread_set_priority(int new_priority)
 {
-	thread_current()->priority = new_priority;
+	struct thread *current = thread_current();
+	bool isdonating = current->priority > current->origin_priority;
+
+	current->origin_priority = new_priority;
+	if (!isdonating)
+	{
+		current->priority = new_priority;
+	}
+
 	if (!list_empty(&ready_list))
 	{
 		struct list_elem *head_elem = list_begin(&ready_list);
 		struct thread *head_thread = list_entry(head_elem, struct thread, elem);
-		if (thread_current()->priority < head_thread->priority)
+		if (current->priority < head_thread->priority)
 		{
 			thread_yield();
 		}
@@ -488,6 +496,7 @@ init_thread(struct thread *t, const char *name, int priority)
 	t->priority = priority;
 	t->origin_priority = priority;
 	t->wait_on_lock = NULL;
+	list_init(&t->donations);
 	t->magic = THREAD_MAGIC;
 }
 


### PR DESCRIPTION
## 변경 내용
- `thread` 구조체에 기본 우선순위(`origin_priority`), 대기 중인 락(`wait_on_lock`), donation 리스트를 추가했습니다.
- `lock_acquire()`에서 락 점유 스레드에 우선순위 donation이 전달되도록 구현했습니다.
- `lock_release()`에서 해당 락에 대한 donation을 제거하고, 남아 있는 donation 기준으로 우선순위를 복구하도록 구현했습니다.
- `thread_set_priority()`에서 donation 중인 경우에도 base priority와 현재 priority가 올바르게 관리되도록 수정했습니다.

## 테스트
| 테스트 | 결과 |
| --- | --- |
| `priority-donate-one` | PASS |
| `priority-donate-multiple` | PASS |
| `priority-donate-multiple2` | PASS |
| `priority-donate-nest` | PASS |
| `priority-donate-sema` | PASS |
| `priority-donate-lower` | PASS |
| `priority-donate-chain` | PASS |

## 리뷰 포인트
- nested donation이 최대 8단계까지만 전파되도록 구현했는데, 이 제한이 현재 프로젝트 요구사항과 맞는지 봐주시면 좋겠습니다.
- `thread_set_priority()`에서 donation 중인 스레드의 base priority만 갱신하고 실제 priority 반영은 donation 해제 시점에 맡기도록 했는데, 이 흐름이 의도한 정책과 맞는지 확인 부탁드립니다.
- donation 리스트 정렬 및 제거 시점이 `priority-donate-one/lower/nest` 외 케이스에서도 안전한지 함께 봐주시면 좋겠습니다.

## PR 체크리스트
- [x] 관련 테스트를 직접 돌렸습니다.
- [x] 테스트 결과를 적었습니다.
- [x] 남은 리스크(리뷰 포인트)가 있으면 적었습니다.
