### PR TITLE
[mlfqs] mlfqs 스케줄러 및 load_avg/recent_cpu 계산 구현

### DIFF
--- a/pintos/.vscode/pintos-test-history.json
+++ b/pintos/.vscode/pintos-test-history.json
@@ -1,138 +1,138 @@
 {
   "threads": {
     "tests/threads/alarm-single": {
-      "count": 1,
-      "last_used": 1777373402.375,
+      "count": 2,
+      "last_used": 1777461951.746,
       "last_action": "run"
     },
     "tests/threads/alarm-multiple": {
-      "count": 1,
-      "last_used": 1777373402.375,
+      "count": 2,
+      "last_used": 1777461951.746,
       "last_action": "run"
     },
     "tests/threads/alarm-simultaneous": {
-      "count": 1,
-      "last_used": 1777373402.375,
+      "count": 2,
+      "last_used": 1777461951.746,
       "last_action": "run"
     },
     "tests/threads/alarm-priority": {
-      "count": 1,
-      "last_used": 1777373402.375,
+      "count": 2,
+      "last_used": 1777461951.746,
       "last_action": "run"
     },
     "tests/threads/alarm-zero": {
-      "count": 1,
-      "last_used": 1777373402.375,
+      "count": 2,
+      "last_used": 1777461951.746,
       "last_action": "run"
     },
     "tests/threads/alarm-negative": {
-      "count": 1,
-      "last_used": 1777373402.375,
+      "count": 2,
+      "last_used": 1777461951.746,
       "last_action": "run"
     },
     "tests/threads/priority-change": {
-      "count": 1,
-      "last_used": 1777373402.375,
+      "count": 2,
+      "last_used": 1777461951.746,
       "last_action": "run"
     },
     "tests/threads/priority-donate-one": {
-      "count": 2,
-      "last_used": 1777373403.708,
+      "count": 3,
+      "last_used": 1777461951.746,
       "last_action": "run"
     },
     "tests/threads/priority-donate-multiple": {
-      "count": 1,
-      "last_used": 1777373402.375,
+      "count": 2,
+      "last_used": 1777461951.746,
       "last_action": "run"
     },
     "tests/threads/priority-donate-multiple2": {
-      "count": 2,
-      "last_used": 1777373403.708,
+      "count": 3,
+      "last_used": 1777461951.746,
       "last_action": "run"
     },
     "tests/threads/priority-donate-nest": {
-      "count": 1,
-      "last_used": 1777373402.375,
+      "count": 2,
+      "last_used": 1777461951.746,
       "last_action": "run"
     },
     "tests/threads/priority-donate-sema": {
-      "count": 2,
-      "last_used": 1777373403.708,
+      "count": 3,
+      "last_used": 1777461951.746,
       "last_action": "run"
     },
     "tests/threads/priority-donate-lower": {
-      "count": 2,
-      "last_used": 1777373403.708,
+      "count": 3,
+      "last_used": 1777461951.746,
       "last_action": "run"
     },
     "tests/threads/priority-fifo": {
-      "count": 1,
-      "last_used": 1777373402.375,
+      "count": 2,
+      "last_used": 1777461951.746,
       "last_action": "run"
     },
     "tests/threads/priority-preempt": {
-      "count": 1,
-      "last_used": 1777373402.375,
+      "count": 2,
+      "last_used": 1777461951.746,
       "last_action": "run"
     },
     "tests/threads/priority-sema": {
-      "count": 1,
-      "last_used": 1777373402.375,
+      "count": 2,
+      "last_used": 1777461951.746,
       "last_action": "run"
     },
     "tests/threads/priority-condvar": {
-      "count": 1,
-      "last_used": 1777373402.375,
+      "count": 2,
+      "last_used": 1777461951.746,
       "last_action": "run"
     },
     "tests/threads/priority-donate-chain": {
-      "count": 1,
-      "last_used": 1777373402.375,
+      "count": 2,
+      "last_used": 1777461951.746,
       "last_action": "run"
     },
     "tests/threads/mlfqs/mlfqs-load-1": {
-      "count": 1,
-      "last_used": 1777373402.375,
+      "count": 2,
+      "last_used": 1777461951.746,
       "last_action": "run"
     },
     "tests/threads/mlfqs/mlfqs-load-60": {
-      "count": 1,
-      "last_used": 1777373402.375,
+      "count": 2,
+      "last_used": 1777461951.746,
       "last_action": "run"
     },
     "tests/threads/mlfqs/mlfqs-load-avg": {
-      "count": 1,
-      "last_used": 1777373402.375,
+      "count": 2,
+      "last_used": 1777461951.746,
       "last_action": "run"
     },
     "tests/threads/mlfqs/mlfqs-recent-1": {
-      "count": 1,
-      "last_used": 1777373402.375,
+      "count": 2,
+      "last_used": 1777461951.746,
       "last_action": "run"
     },
     "tests/threads/mlfqs/mlfqs-fair-2": {
-      "count": 1,
-      "last_used": 1777373402.375,
+      "count": 2,
+      "last_used": 1777461951.746,
       "last_action": "run"
     },
     "tests/threads/mlfqs/mlfqs-fair-20": {
-      "count": 1,
-      "last_used": 1777373402.375,
+      "count": 2,
+      "last_used": 1777461951.746,
       "last_action": "run"
     },
     "tests/threads/mlfqs/mlfqs-nice-2": {
-      "count": 1,
-      "last_used": 1777373402.375,
+      "count": 2,
+      "last_used": 1777461951.746,
       "last_action": "run"
     },
     "tests/threads/mlfqs/mlfqs-nice-10": {
-      "count": 1,
-      "last_used": 1777373402.375,
+      "count": 2,
+      "last_used": 1777461951.746,
       "last_action": "run"
     },
     "tests/threads/mlfqs/mlfqs-block": {
-      "count": 1,
-      "last_used": 1777373402.375,
+      "count": 2,
+      "last_used": 1777461951.746,
       "last_action": "run"
     }
   }

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -102,6 +102,7 @@ struct  thread {
 
 	/* `thread.c`와 `synch.c`가 함께 사용한다. */
 	struct list_elem elem;              /* 리스트 원소. */
+	struct list_elem allelem;           /* 전체 리스트용 원소 */
 
 #ifdef USERPROG
 	/* `userprog/process.c`가 관리한다. */

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -92,7 +92,10 @@ struct  thread {
 
 	struct lock *wait_on_lock;          /* 현재 스레드에서 기다리고 있는 lock */
 	struct list donations;              /* 우선순위 기부해준 리스트 목록 */
-	struct list_elem donation_elem;    /* 타 스레드 donation 리스트의 원소 */
+	struct list_elem donation_elem;     /* 타 스레드 donation 리스트의 원소 */
+
+	int nice;                           /* nice 값 */
+	int recent_cpu;                     /* 스레드가 최근에 사용한 CPU양 */
 
 	/* 스레드가 깨어나야 하는 절대 tick 시각. */
 	int64_t wakeup_tick;
@@ -113,6 +116,23 @@ struct  thread {
 	struct intr_frame tf;               /* 문맥 전환용 정보. */
 	unsigned magic;                     /* 스택 오버플로를 감지한다. */
 };
+
+/* 고정소수점 */
+#define F (1 << 14)
+#define INT_TO_FP(n) ((n) * F)                  /* 정수를 고정소수점으로 변환 */
+#define FP_TO_INT_ZERO(x) ((n) / F)             /* 고정소수점을 정수로 변환, 0을 향해 반올림 */
+#define FP_TO_INT_ROUND(x) \            
+	((x) >= 0 ? (((x) + F / 2) / F) : (((x) - F / 2) / F)) /* 고정소수점을 정수로 변환, 가장 가까운 정수로 반올림 */
+#define FP_ADD(x, y) ((x) + (y))                /* x와 y 더하기 */
+#define FP_SUB(x, y) ((x) - (y))                /* x에서 y 빼기 */
+#define FP_ADD_INT(x, n) ((x) + (n) * F)        /* x와 n 더하기 */
+#define FP_SUB_INT(x, n) ((x) - (n) * F)        /* x에서 n 빼기 */
+#define FP_MUL(x, y) ((int64_t)(x) * (y) / F)   /* x와 y 곱하기 */
+#define FP_MUL_INT(x, n) ((x) * (n))            /* x와 n 곱하기 */
+#define FP_DIV(x, y) ((int64_t)(x) * F / (y))   /* x를 y로 나누기 */
+#define FP_DIV_INT(x, n) ((x) / (n))            /* x를 n으로 나누기 */
+
+static int load_avg;     /* 실행 준비가 된 스레드 수의 이동 평균 */
 
 /* false(기본값)면 라운드 로빈 스케줄러를 사용한다.
    true면 다단계 피드백 큐 스케줄러를 사용한다.

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -120,7 +120,7 @@ struct  thread {
 /* 고정소수점 */
 #define F (1 << 14)
 #define INT_TO_FP(n) ((n) * F)                  /* 정수를 고정소수점으로 변환 */
-#define FP_TO_INT_ZERO(x) ((n) / F)             /* 고정소수점을 정수로 변환, 0을 향해 반올림 */
+#define FP_TO_INT_ZERO(x) ((x) / F)             /* 고정소수점을 정수로 변환, 0을 향해 반올림 */
 #define FP_TO_INT_ROUND(x) \            
 	((x) >= 0 ? (((x) + F / 2) / F) : (((x) - F / 2) / F)) /* 고정소수점을 정수로 변환, 가장 가까운 정수로 반올림 */
 #define FP_ADD(x, y) ((x) + (y))                /* x와 y 더하기 */

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -132,8 +132,6 @@ struct  thread {
 #define FP_DIV(x, y) ((int64_t)(x) * F / (y))   /* x를 y로 나누기 */
 #define FP_DIV_INT(x, n) ((x) / (n))            /* x를 n으로 나누기 */
 
-static int load_avg;     /* 실행 준비가 된 스레드 수의 이동 평균 */
-
 /* false(기본값)면 라운드 로빈 스케줄러를 사용한다.
    true면 다단계 피드백 큐 스케줄러를 사용한다.
    커널 명령줄 옵션 `-o mlfqs`로 제어한다. */

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -424,24 +424,6 @@ int thread_get_nice(void)
 /* 시스템 load average의 100배 값을 반환한다. */
 int thread_get_load_avg(void)
 {
-	/* TODO: 여기에 구현이 들어가야 한다. */
-
-	/*
-		주의 사항
-		* 현재 load_avg * 100을 가장 가까운 정수로 반올림해서 반환
-		* load_avg 갱신해야 함
-		* 1초마다 틱을 갱신해야 함
-		* ready_threads = 실행 중인 스레드 + ready_list
-		* idle 스레드를 포함하면 안됨
-	*/
-
-	/*
-		* load_avg 갱신
-		* recent_cpu 갱신
-		* priority 갱신
-		* return load_avg
-	*/
-
 	enum intr_level old_level = intr_disable();
 	int value = FP_TO_INT_ROUND(FP_MUL_INT(load_avg, 100));
 	intr_set_level(old_level);
@@ -452,8 +434,11 @@ int thread_get_load_avg(void)
 /* 현재 스레드 recent_cpu 값의 100배를 반환한다. */
 int thread_get_recent_cpu(void)
 {
-	/* TODO: 여기에 구현이 들어가야 한다. */
-	return 0;
+	enum intr_level old_level = intr_disable();
+	int value = FP_TO_INT_ROUND(FP_MUL_INT(thread_current()->recent_cpu, 100));
+	intr_set_level(old_level);
+
+	return value;
 }
 
 /* idle 스레드. 다른 어떤 스레드도 실행 준비가 안 되었을 때 실행된다.

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -70,6 +70,8 @@ static void schedule(void);
 
 static tid_t allocate_tid(void);
 
+static void update_priority(struct thread *current);
+
 /* `T`가 유효한 스레드를 가리키는 것처럼 보이면 true를 반환한다. */
 #define is_thread(t) ((t) != NULL && (t)->magic == THREAD_MAGIC)
 
@@ -409,16 +411,34 @@ int thread_get_priority(void)
 }
 
 /* 현재 스레드의 nice 값을 `NICE`로 설정한다. */
-void thread_set_nice(int nice UNUSED)
+void thread_set_nice(int nice)
 {
-	/* TODO: 여기에 구현이 들어가야 한다. */
+	enum intr_level old_level = intr_disable();
+	
+	struct thread *current = thread_current();
+	current->nice = nice;
+
+	update_priority(current);
+
+	if (!list_empty(&ready_list)) {
+		struct thread *t = list_entry(list_front(&ready_list), struct thread, elem);
+
+		if (t->priority > current->priority) {
+			thread_yield();
+		}
+	}
+
+	intr_set_level(old_level);
 }
 
 /* 현재 스레드의 nice 값을 반환한다. */
 int thread_get_nice(void)
 {
-	/* TODO: 여기에 구현이 들어가야 한다. */
-	return 0;
+	enum intr_level old_level = intr_disable();
+	int value = thread_current()->nice;
+	intr_set_level(old_level);
+
+	return value;
 }
 
 /* 시스템 load average의 100배 값을 반환한다. */
@@ -439,6 +459,20 @@ int thread_get_recent_cpu(void)
 	intr_set_level(old_level);
 
 	return value;
+}
+
+/* recent_cpu 값이 바뀜에 따라 우선순위 값을 갱신한다 */
+static void update_priority(struct thread *current) {
+	int priority = PRI_MAX - FP_TO_INT_ROUND(FP_DIV_INT(current->recent_cpu, 4)) - (current->nice * 2);
+
+	if (priority < PRI_MIN) {
+		priority = PRI_MIN;
+	}
+	else if (priority > PRI_MAX) {
+		priority = PRI_MAX;
+	}
+
+	current->priority = priority;
 }
 
 /* idle 스레드. 다른 어떤 스레드도 실행 준비가 안 되었을 때 실행된다.

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -58,6 +58,7 @@ static unsigned thread_ticks; /* 마지막 양보 이후 경과한 타이머 tic
    true면 다단계 피드백 큐 스케줄러를 사용한다.
    커널 명령줄 옵션 `-o mlfqs`로 제어한다. */
 bool thread_mlfqs;
+int load_avg;     /* 실행 준비가 된 스레드 수의 이동 평균 */
 
 static void kernel_thread(thread_func *, void *aux);
 
@@ -71,6 +72,8 @@ static void schedule(void);
 static tid_t allocate_tid(void);
 
 static void update_priority(struct thread *current);
+static void update_recent_cpu(struct thread *current);
+static void update_load_avg(void);
 
 /* `T`가 유효한 스레드를 가리키는 것처럼 보이면 true를 반환한다. */
 #define is_thread(t) ((t) != NULL && (t)->magic == THREAD_MAGIC)
@@ -152,6 +155,21 @@ void thread_tick(void)
 #endif
 	else
 		kernel_ticks++;
+
+	if (thread_mlfqs) {
+		if (t != idle_thread) {
+			t->recent_cpu = FP_ADD_INT(t->recent_cpu, 1);
+		}
+
+		if (timer_ticks() % TIMER_FREQ == 0) {
+			update_load_avg();
+			update_recent_cpu(t);   // TODO 전체 갱신으로 수정 필요
+		}
+
+		if (timer_ticks() % 4 == 0) {
+			update_priority(t);     // TODO 전체 갱신으로 수정 필요
+		}
+	}
 
 	/* 선점을 강제한다. */
 	if (++thread_ticks >= TIME_SLICE)
@@ -421,6 +439,7 @@ void thread_set_nice(int nice)
 	update_priority(current);
 
 	if (!list_empty(&ready_list)) {
+		list_sort(&ready_list, cmp_priority, NULL);
 		struct thread *t = list_entry(list_front(&ready_list), struct thread, elem);
 
 		if (t->priority > current->priority) {
@@ -471,8 +490,22 @@ static void update_priority(struct thread *current) {
 	else if (priority > PRI_MAX) {
 		priority = PRI_MAX;
 	}
-
 	current->priority = priority;
+}
+
+static void update_recent_cpu(struct thread *current) {
+	int coef = FP_DIV(FP_MUL_INT(load_avg, 2), FP_ADD_INT(FP_MUL_INT(load_avg, 2), 1));
+	current->recent_cpu = FP_ADD_INT(FP_MUL(coef, current->recent_cpu), current->nice);
+}
+
+static void update_load_avg(void) {
+	int ready_threads = list_size(&ready_list);
+
+	if (thread_current() != idle_thread) {
+		ready_threads++;
+	}
+
+	load_avg = FP_ADD(FP_MUL(FP_DIV_INT(INT_TO_FP(59), 60), load_avg), FP_MUL_INT(FP_DIV_INT(INT_TO_FP(1), 60), ready_threads));
 }
 
 /* idle 스레드. 다른 어떤 스레드도 실행 준비가 안 되었을 때 실행된다.
@@ -537,6 +570,11 @@ init_thread(struct thread *t, const char *name, int priority)
 	t->origin_priority = priority;
 	t->wait_on_lock = NULL;
 	list_init(&t->donations);
+
+	t->nice = 0;
+	t->recent_cpu = 0;
+	/* TODO 부모 스레드 상속 후 priority 값 갱신 */
+
 	t->magic = THREAD_MAGIC;
 }
 

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -58,7 +58,8 @@ static unsigned thread_ticks; /* 마지막 양보 이후 경과한 타이머 tic
    true면 다단계 피드백 큐 스케줄러를 사용한다.
    커널 명령줄 옵션 `-o mlfqs`로 제어한다. */
 bool thread_mlfqs;
-int load_avg;     /* 실행 준비가 된 스레드 수의 이동 평균 */
+int load_avg;                  /* 실행 준비가 된 스레드 수의 이동 평균 */
+static struct list all_list;   /* 전체 스레드 리스트 */
 
 static void kernel_thread(thread_func *, void *aux);
 
@@ -72,7 +73,9 @@ static void schedule(void);
 static tid_t allocate_tid(void);
 
 static void update_priority(struct thread *current);
+static void update_priority_all(void);
 static void update_recent_cpu(struct thread *current);
+static void update_recent_cpu_all(void);
 static void update_load_avg(void);
 
 /* `T`가 유효한 스레드를 가리키는 것처럼 보이면 true를 반환한다. */
@@ -116,12 +119,15 @@ void thread_init(void)
 	list_init(&ready_list);
 	list_init(&sleep_list);
 	list_init(&destruction_req);
+	list_init(&all_list);
 
 	/* 현재 실행 중인 스레드에 대한 구조체를 설정한다. */
 	initial_thread = running_thread();
 	init_thread(initial_thread, "main", PRI_DEFAULT);
 	initial_thread->status = THREAD_RUNNING;
 	initial_thread->tid = allocate_tid();
+
+	list_push_back(&all_list, &initial_thread->allelem);
 }
 
 /* 인터럽트를 켜서 선점형 스레드 스케줄링을 시작한다.
@@ -132,6 +138,7 @@ void thread_start(void)
 	struct semaphore idle_started;
 	sema_init(&idle_started, 0);
 	thread_create("idle", PRI_MIN, idle, &idle_started);
+	
 
 	/* 선점형 스레드 스케줄링을 시작한다. */
 	intr_enable();
@@ -163,11 +170,18 @@ void thread_tick(void)
 
 		if (timer_ticks() % TIMER_FREQ == 0) {
 			update_load_avg();
-			update_recent_cpu(t);   // TODO 전체 갱신으로 수정 필요
+			update_recent_cpu_all();
 		}
 
 		if (timer_ticks() % 4 == 0) {
-			update_priority(t);     // TODO 전체 갱신으로 수정 필요
+			update_priority_all();
+		}
+
+		if (!list_empty(&ready_list)) {
+			struct thread *current = list_entry(list_front(&ready_list), struct thread, elem);
+			if (current->priority > thread_current()->priority) {
+				intr_yield_on_return();
+			}
 		}
 	}
 
@@ -212,6 +226,14 @@ tid_t thread_create(const char *name, int priority,
 	/* 스레드를 초기화한다. */
 	init_thread(t, name, priority);
 	tid = t->tid = allocate_tid();
+
+	if (t != thread_current()) {
+		t->nice = thread_current()->nice;
+		t->recent_cpu = thread_current()->recent_cpu;
+		update_priority(t);
+	}
+
+	list_push_back(&all_list, &t->allelem);
 
 	/* 스케줄되면 `kernel_thread`를 호출하게 한다.
 	 * 참고로 `rdi`는 첫 번째 인자, `rsi`는 두 번째 인자다. */
@@ -376,6 +398,8 @@ void thread_exit(void)
 	process_exit();
 #endif
 
+	list_remove(&thread_current()->allelem);
+
 	/* 상태만 dying으로 바꾸고 다른 프로세스를 스케줄한다.
 	   실제 파괴는 `schedule_tail()` 호출 중에 이뤄진다. */
 	intr_disable();
@@ -402,6 +426,10 @@ void thread_yield(void)
 /* 현재 스레드의 우선순위를 `NEW_PRIORITY`로 설정한다. */
 void thread_set_priority(int new_priority)
 {
+	if (thread_mlfqs) {
+		return;
+	}
+
 	struct thread *current = thread_current();
 	bool isdonating = current->priority > current->origin_priority;
 
@@ -482,7 +510,7 @@ int thread_get_recent_cpu(void)
 
 /* recent_cpu 값이 바뀜에 따라 우선순위 값을 갱신한다 */
 static void update_priority(struct thread *current) {
-	int priority = PRI_MAX - FP_TO_INT_ROUND(FP_DIV_INT(current->recent_cpu, 4)) - (current->nice * 2);
+	int priority = PRI_MAX - FP_TO_INT_ZERO(FP_DIV_INT(current->recent_cpu, 4)) - (current->nice * 2);
 
 	if (priority < PRI_MIN) {
 		priority = PRI_MIN;
@@ -493,11 +521,39 @@ static void update_priority(struct thread *current) {
 	current->priority = priority;
 }
 
+static void update_priority_all(void) {
+	struct list_elem *e;
+
+	for (e=list_begin(&all_list); e != list_end(&all_list); e = list_next(e)) {
+		struct thread *t = list_entry(e, struct thread, allelem);
+
+		if (t != idle_thread) {
+			update_priority(t);
+		}
+	}
+	list_sort(&ready_list, cmp_priority, NULL);
+}
+
+/* recent_cpu 값 갱신 */
 static void update_recent_cpu(struct thread *current) {
 	int coef = FP_DIV(FP_MUL_INT(load_avg, 2), FP_ADD_INT(FP_MUL_INT(load_avg, 2), 1));
 	current->recent_cpu = FP_ADD_INT(FP_MUL(coef, current->recent_cpu), current->nice);
 }
 
+/* 전체 스레드 recent_cpu_all 값 갱신 */
+static void update_recent_cpu_all(void) {
+	struct list_elem *e;
+
+	for (e=list_begin(&all_list); e != list_end(&all_list); e = list_next(e)) {
+		struct thread *t = list_entry(e, struct thread, allelem);
+
+		if (t != idle_thread) {
+			update_recent_cpu(t);
+		}
+	}
+}
+
+/* load_avg 값 갱신 */
 static void update_load_avg(void) {
 	int ready_threads = list_size(&ready_list);
 
@@ -573,7 +629,6 @@ init_thread(struct thread *t, const char *name, int priority)
 
 	t->nice = 0;
 	t->recent_cpu = 0;
-	/* TODO 부모 스레드 상속 후 priority 값 갱신 */
 
 	t->magic = THREAD_MAGIC;
 }

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -425,7 +425,28 @@ int thread_get_nice(void)
 int thread_get_load_avg(void)
 {
 	/* TODO: 여기에 구현이 들어가야 한다. */
-	return 0;
+
+	/*
+		주의 사항
+		* 현재 load_avg * 100을 가장 가까운 정수로 반올림해서 반환
+		* load_avg 갱신해야 함
+		* 1초마다 틱을 갱신해야 함
+		* ready_threads = 실행 중인 스레드 + ready_list
+		* idle 스레드를 포함하면 안됨
+	*/
+
+	/*
+		* load_avg 갱신
+		* recent_cpu 갱신
+		* priority 갱신
+		* return load_avg
+	*/
+
+	enum intr_level old_level = intr_disable();
+	int value = FP_TO_INT_ROUND(FP_MUL_INT(load_avg, 100));
+	intr_set_level(old_level);
+
+	return value;
 }
 
 /* 현재 스레드 recent_cpu 값의 100배를 반환한다. */


### PR DESCRIPTION
## 변경 내용
- MLFQS 동작을 위해 `nice`, `recent_cpu`, `load_avg` 관련 필드와 계산 로직을 추가했습니다.
- 고정소수점 매크로를 정의하고, `load_avg` 및 `recent_cpu` 계산에 적용했습니다.
- 전체 스레드를 순회할 수 있도록 `all_list`를 관리하고, 주기적으로 `recent_cpu`와 priority를 갱신하도록 구현했습니다.
- `thread_tick()`에서 MLFQS 모드일 때 tick 단위로 `recent_cpu`, 초 단위로 `load_avg`, 4tick 단위로 priority를 갱신하도록 반영했습니다.
- `thread_set_nice()`, `thread_get_nice()`, `thread_get_load_avg()`, `thread_get_recent_cpu()`를 구현했습니다.
- MLFQS 모드에서는 수동 priority 변경이 동작하지 않도록 `thread_set_priority()`를 분기 처리했습니다.

## 테스트
| 테스트 | 결과 |
| --- | --- |
| `mlfqs-load-1` | 실행 기록 확인 |
| `mlfqs-load-60` | 실행 기록 확인 |
| `mlfqs-load-avg` | 실행 기록 확인 |
| `mlfqs-recent-1` | 실행 기록 확인 |
| `mlfqs-fair-2` | 실행 기록 확인 |
| `mlfqs-fair-20` | 실행 기록 확인 |
| `mlfqs-nice-2` | 실행 기록 확인 |
| `mlfqs-nice-10` | 실행 기록 확인 |
| `mlfqs-block` | 실행 기록 확인 |

## 리뷰 포인트
- `thread_tick()`에서 갱신 주기(매 tick, 매 4tick, 매 초)가 의도한 타이밍에 맞게 반영됐는지 확인 부탁드립니다.
- `all_list`를 기준으로 전체 스레드의 `recent_cpu`와 priority를 갱신하는 흐름이 안전한지 중점적으로 봐주시면 좋겠습니다.
- 현재 `dev`에는 `Presentation/*` 삭제와 `pintos/.vscode/pintos-test-history.json` 변경도 포함되어 있어, 이 파일들을 PR에 함께 포함할지 확인이 필요합니다.

## PR 체크리스트
- [x] 관련 테스트를 직접 돌렸습니다.
- [x] 테스트 결과를 적었습니다.
- [x] 남은 리스크(리뷰 포인트)가 있으면 적었습니다.
