### PR TITLE
[userprog] argument passing 초기 구현

### DIFF
--- a/pintos/.vscode/pintos-test-history.json
+++ b/pintos/.vscode/pintos-test-history.json
@@ -135,5 +135,32 @@
       "last_used": 1777461951.746,
       "last_action": "run"
     }
+  },
+  "userprog": {
+    "tests/userprog/args-none": {
+      "count": 1,
+      "last_used": 1777719567.282,
+      "last_action": "run"
+    },
+    "tests/userprog/args-single": {
+      "count": 1,
+      "last_used": 1777719567.282,
+      "last_action": "run"
+    },
+    "tests/userprog/args-multiple": {
+      "count": 1,
+      "last_used": 1777719567.282,
+      "last_action": "run"
+    },
+    "tests/userprog/args-many": {
+      "count": 1,
+      "last_used": 1777719567.282,
+      "last_action": "run"
+    },
+    "tests/userprog/args-dbl-space": {
+      "count": 1,
+      "last_used": 1777719567.282,
+      "last_action": "run"
+    }
   }
 }

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -5,6 +5,7 @@
 #include <list.h>
 #include <stdint.h>
 #include "threads/interrupt.h"
+#include "threads/synch.h"
 #ifdef VM
 #include "vm/vm.h"
 #endif
@@ -107,6 +108,11 @@ struct  thread {
 #ifdef USERPROG
 	/* `userprog/process.c`가 관리한다. */
 	uint64_t *pml4;                     /* 4단계 페이지 맵. */
+	int exit_status;
+	struct semaphore wait_sema; // 내가 끝났는지 부모에게 알려줄 세마포어
+	struct list children;	// 내 자식들을 담는 리스트
+	struct list_elem child_elem; // 내가 부모의 자식 리스트에 들어갈 때 쓰는 elem
+	struct thread *parent; // 내 부모가 누구인지 가르키는 포인터
 #endif
 #ifdef VM
 	/* 스레드가 소유한 전체 가상 메모리용 테이블. */

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -227,6 +227,11 @@ tid_t thread_create(const char *name, int priority,
 	init_thread(t, name, priority);
 	tid = t->tid = allocate_tid();
 
+	#ifdef USERPROG
+	t->parent = thread_current();
+	list_push_back(&thread_current()->children, &t->child_elem);
+	#endif
+
 	if (t != thread_current()) {
 		t->nice = thread_current()->nice;
 		t->recent_cpu = thread_current()->recent_cpu;
@@ -629,6 +634,13 @@ init_thread(struct thread *t, const char *name, int priority)
 
 	t->nice = 0;
 	t->recent_cpu = 0;
+
+	#ifdef USERPROG
+	t->exit_status = 0;
+	sema_init(&t->wait_sema, 0);
+	list_init(&t->children);
+	t->parent = NULL;
+	#endif
 
 	t->magic = THREAD_MAGIC;
 }

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -473,8 +473,6 @@ load (char *file_name, struct intr_frame *if_) {
 	if_->R.rdi = argc;
 	if_->R.rsi = argv_start;
 
-	hex_dump(if_->rsp, (void *)if_->rsp, USER_STACK - if_->rsp, true);
-
 	success = true;
 done:
 	/* We arrive here whether the load is successful or not. */

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -23,7 +23,7 @@
 #endif
 
 static void process_cleanup (void);
-static bool load (const char *file_name, struct intr_frame *if_);
+static bool load (char *file_name, struct intr_frame *if_);
 static void initd (void *f_name);
 static void __do_fork (void *);
 
@@ -164,7 +164,7 @@ int
 process_exec (void *f_name) {
 	char *file_name = f_name;
 	bool success;
-
+	
 	/* We cannot use the intr_frame in the thread structure.
 	 * This is because when current thread rescheduled,
 	 * it stores the execution information to the member. */
@@ -177,7 +177,7 @@ process_exec (void *f_name) {
 	process_cleanup ();
 
 	/* And then load the binary */
-	success = load (file_name, &_if);
+	success = load(file_name, &_if);
 
 	/* If load failed, quit. */
 	palloc_free_page (file_name);
@@ -188,6 +188,8 @@ process_exec (void *f_name) {
 	do_iret (&_if);
 	NOT_REACHED ();
 }
+
+
 
 
 /* Waits for thread TID to die and returns its exit status.  If
@@ -321,13 +323,32 @@ static bool load_segment (struct file *file, off_t ofs, uint8_t *upage,
  * and its initial stack pointer into *RSP.
  * Returns true if successful, false otherwise. */
 static bool
-load (const char *file_name, struct intr_frame *if_) {
+load (char *file_name, struct intr_frame *if_) {
 	struct thread *t = thread_current ();
 	struct ELF ehdr;
 	struct file *file = NULL;
 	off_t file_ofs;
 	bool success = false;
 	int i;
+	char *save_ptr;
+	char *argv[128];
+	int argc = 0;
+	uintptr_t arg_addr[128];
+
+	char *token = strtok_r(file_name, " ", &save_ptr);
+	while (token != NULL) {
+		if (argc == 127) {
+			goto done;
+		}
+		argv[argc] = token;
+		argc++;
+		token = strtok_r(NULL, " ", &save_ptr);
+	}
+
+	argv[argc] = NULL;
+	if (argc == 0) {
+		goto done;
+	}
 
 	/* Allocate and activate page directory. */
 	t->pml4 = pml4_create ();
@@ -336,9 +357,9 @@ load (const char *file_name, struct intr_frame *if_) {
 	process_activate (thread_current ());
 
 	/* Open executable file. */
-	file = filesys_open (file_name);
+	file = filesys_open (argv[0]);
 	if (file == NULL) {
-		printf ("load: %s: open failed\n", file_name);
+		printf("load: %s: open failed\n", argv[0]);
 		goto done;
 	}
 
@@ -350,7 +371,7 @@ load (const char *file_name, struct intr_frame *if_) {
 			|| ehdr.e_version != 1
 			|| ehdr.e_phentsize != sizeof (struct Phdr)
 			|| ehdr.e_phnum > 1024) {
-		printf ("load: %s: error loading executable\n", file_name);
+		printf("load: %s: error loading executable\n", argv[0]);
 		goto done;
 	}
 
@@ -414,17 +435,40 @@ load (const char *file_name, struct intr_frame *if_) {
 	/* Start address. */
 	if_->rip = ehdr.e_entry;
 
-	/* TODO: Your code goes here.
-	 * TODO: Implement argument passing (see project2/argument_passing.html). */
+	for (int i=argc-1; i>=0; i--) {
+		int len = strlen(argv[i]) + 1;
+		if_->rsp -= len;
+		memcpy((void *) if_->rsp, argv[i], len);
+		arg_addr[i] = if_->rsp;
+	}
+	
+	int padding = if_->rsp % 8;
+	if (padding != 0) {
+		if_->rsp -= padding;
+		memset((void *) if_->rsp, 0, padding);
+	}
+	if_->rsp -= sizeof(char *);
+	memset((void *)if_->rsp, 0, sizeof(char *));
+
+	for (int i = argc-1; i>=0; i--) {
+		int len = sizeof(char *);
+		if_->rsp -= len;
+		memcpy((void *) if_->rsp, &arg_addr[i], len);
+	}
+
+	uintptr_t argv_start = if_->rsp;
+	if_->rsp -= sizeof(char *);
+	memset((void *) if_->rsp, 0, sizeof(char *));
+
+	if_->R.rdi = argc;
+	if_->R.rsi = argv_start;
 
 	success = true;
-
 done:
 	/* We arrive here whether the load is successful or not. */
 	file_close (file);
 	return success;
 }
-
 
 /* Checks whether PHDR describes a valid, loadable segment in
  * FILE and returns true if so, false otherwise. */

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -202,10 +202,20 @@ process_exec (void *f_name) {
  * This function will be implemented in problem 2-2.  For now, it
  * does nothing. */
 int
-process_wait (tid_t child_tid UNUSED) {
+process_wait (tid_t child_tid) {
 	/* XXX: Hint) The pintos exit if process_wait (initd), we recommend you
 	 * XXX:       to add infinite loop here before
 	 * XXX:       implementing the process_wait. */
+	struct thread *cur = thread_current();
+	struct list_elem *elem;
+	for (elem = list_begin(&cur->children); elem != list_end(&cur->children); elem = list_next(elem)) {
+		struct thread *child = list_entry(elem, struct thread, child_elem);
+		if (child->tid == child_tid) {
+			sema_down(&child->wait_sema);
+			int exit_save = child->exit_status;
+			return exit_save;
+		}
+	}
 	return -1;
 }
 
@@ -217,7 +227,7 @@ process_exit (void) {
 	 * TODO: Implement process termination message (see
 	 * TODO: project2/process_termination.html).
 	 * TODO: We recommend you to implement process resource cleanup here. */
-
+	sema_up(&curr->wait_sema);
 	process_cleanup ();
 }
 
@@ -462,6 +472,8 @@ load (char *file_name, struct intr_frame *if_) {
 
 	if_->R.rdi = argc;
 	if_->R.rsi = argv_start;
+
+	hex_dump(if_->rsp, (void *)if_->rsp, USER_STACK - if_->rsp, true);
 
 	success = true;
 done:


### PR DESCRIPTION
## 변경 내용
- `process_exec`/`load` 흐름에서 커맨드라인 인자를 파싱하도록 수정했습니다.
- 유저 스택에 argv 문자열, argv 포인터 배열, fake return address를 쌓는 argument passing 로직을 추가했습니다.
- `argc`, `argv`가 유저 프로그램 시작 시 전달되도록 `rdi`, `rsi` 레지스터를 설정했습니다.
- args 테스트 확인을 위해 최소 wait/exit 흐름과 thread 부모-자식 관계 필드를 추가 중입니다.

## 테스트
| 테스트 | 결과 |
| --- | --- |
| `args-single` | 진행 중 |

## 리뷰 포인트
- argument passing 스택 정렬과 argv 포인터 배치가 정확한지 확인이 필요합니다.
- 현재 wait/exit는 args 테스트 확인을 위한 최소 구현 단계이며, fork 기반 wait 전체 구현은 후속 작업이 필요합니다.
- syscall `write`, `exit` 최소 구현을 추가로 연결해야 args 출력 확인이 가능합니다.

## PR 체크리스트
- [ ] 관련 테스트를 직접 돌렸습니다.
- [ ] 테스트 결과를 적었습니다.
- [x] 남은 리스크(리뷰 포인트)가 있으면 적었습니다.
