### PR TITLE
[syscall] create/open/close 시스템콜 구현

### DIFF
--- a/pintos/filesys/filesys.c
+++ b/pintos/filesys/filesys.c
@@ -56,15 +56,17 @@ filesys_done (void) {
 /* Creates a file named NAME with the given INITIAL_SIZE.
  * Returns true if successful, false otherwise.
  * Fails if a file named NAME already exists,
- * or if internal memory allocation fails. */
+ * or if internal memory allocation fails.
+ * name = 만들 파일 이름, initial_size = 파일 초기 크기 */
 bool
 filesys_create (const char *name, off_t initial_size) {
 	disk_sector_t inode_sector = 0;
 	struct dir *dir = dir_open_root ();
+	// 루트 디렉토리 열기 성공 && 디스크에서 inode용 빈 섹터 1개할당 && 그 섹터에 파일 inode 생성 성공 && 루트 티렉터리 이름등록 -> True
 	bool success = (dir != NULL
 			&& free_map_allocate (1, &inode_sector)
 			&& inode_create (inode_sector, initial_size)
-			&& dir_add (dir, name, inode_sector));
+			&& dir_add (dir, name, inode_sector));	// 이름 공백, 최대길이, 중복이름 검사
 	if (!success && inode_sector != 0)
 		free_map_release (inode_sector, 1);
 	dir_close (dir);

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -82,6 +82,14 @@ typedef int tid_t;
  * 원소가 될 수도 있다. 이 두 용도가 동시에 겹치지 않는 이유는
  * 준비 상태의 스레드만 실행 큐에 있고, 블록 상태의 스레드만
  * 세마포어 대기 리스트에 있기 때문이다. */
+struct file;
+struct fd_entry {
+	int fd;                    /* fd 번호 */
+	struct file *file;         /* 실제 열린 파일 객체 */
+	struct list_elem elem;     /* fd_list에 연결되기 위한 노드 */
+};
+
+
 struct  thread {
 	/* `thread.c`가 관리한다. */
 	tid_t tid;                          /* 스레드 식별자. */
@@ -109,6 +117,8 @@ struct  thread {
 #ifdef USERPROG
 	/* `userprog/process.c`가 관리한다. */
 	uint64_t *pml4;                     /* 4단계 페이지 맵. */
+	struct list fd_list;	// 현재 프로세스가 열어둔 파일 목록
+	int next_fd;	// Open 때 줄 번호
 #endif
 #ifdef VM
 	/* 스레드가 소유한 전체 가상 메모리용 테이블. */

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -626,6 +626,10 @@ init_thread(struct thread *t, const char *name, int priority)
 	t->origin_priority = priority;
 	t->wait_on_lock = NULL;
 	list_init(&t->donations);
+	#ifdef USERPROG
+	list_init(&t->fd_list);
+	t->next_fd = 2;
+	#endif
 
 	t->nice = 0;
 	t->recent_cpu = 0;

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -230,7 +230,9 @@ tid_t thread_create(const char *name, int priority,
 	if (t != thread_current()) {
 		t->nice = thread_current()->nice;
 		t->recent_cpu = thread_current()->recent_cpu;
-		update_priority(t);
+		if (thread_mlfqs) {
+				update_priority(t);
+		}
 	}
 
 	list_push_back(&all_list, &t->allelem);

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -62,7 +62,13 @@ syscall_handler (struct intr_frame *f UNUSED) {
 	}
 
 	case SYS_CREATE: {
-		
+		const char *file = (const char *) f->R.rdi;
+		unsigned size = f->R.rsi;
+		lock_acquire(&filesys_lock);
+		bool result = filesys_create(file, size);
+		lock_release(&filesys_lock);
+		f->R.rax = result;
+		break;
 	}
 
 	case SYS_WRITE: {

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -9,9 +9,14 @@
 #include "threads/flags.h"
 #include "threads/init.h"
 #include "intrinsic.h"
+#include "filesys/filesys.h"
+#include "threads/synch.h"
+#include "threads/vaddr.h"
+#include "threads/mmu.h"
 
 void syscall_entry (void);
 void syscall_handler (struct intr_frame *);
+static struct lock filesys_lock;
 
 /* 시스템 호출.
  *
@@ -37,6 +42,7 @@ syscall_init (void) {
 	 * FLAG_FL을 마스킹한다. */
 	write_msr(MSR_SYSCALL_MASK,
 			FLAG_IF | FLAG_TF | FLAG_DF | FLAG_IOPL | FLAG_AC | FLAG_NT);
+	lock_init(&filesys_lock);
 }
 
 /* 메인 시스템 호출 인터페이스 */
@@ -55,6 +61,10 @@ syscall_handler (struct intr_frame *f UNUSED) {
 		break;
 	}
 
+	case SYS_CREATE: {
+		
+	}
+
 	case SYS_WRITE: {
 		if ((int) f->R.rdi == 1) {
 			putbuf((const char *) f->R.rsi, (size_t) f->R.rdx);
@@ -69,5 +79,27 @@ syscall_handler (struct intr_frame *f UNUSED) {
 	
 	default:
 		break;
+	}
+}
+
+/*
+포인터가 null 이거나 커널 주소거나 매핑 안 된 주소면 커널이 터질 수 있음
+문자열 포인터가 유효한지 검사하는 함수
+*/
+static void check_user_string(const char *s) {
+	struct thread *cur = thread_current();
+	if (s == NULL) {
+		cur->exit_status = -1;
+		thread_exit();
+	}
+	while (true) {
+		if (!is_user_vaddr(s) || pml4_get_page(cur->pml4, s) == NULL) {
+			cur->exit_status = -1;
+			thread_exit();
+		}
+		if (*s == '\0') {
+			break;
+		}
+		s++;
 	}
 }

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -10,9 +10,11 @@
 #include "threads/init.h"
 #include "intrinsic.h"
 #include "filesys/filesys.h"
+#include "filesys/file.h"
 #include "threads/synch.h"
 #include "threads/vaddr.h"
 #include "threads/mmu.h"
+#include "threads/malloc.h"
 
 void syscall_entry (void);
 void syscall_handler (struct intr_frame *);
@@ -69,6 +71,30 @@ syscall_handler (struct intr_frame *f UNUSED) {
 		lock_release(&filesys_lock);
 		f->R.rax = result;
 		break;
+	}
+
+	case SYS_OPEN: {
+		const char *file = (const char *) f->R.rdi;
+		lock_acquire(&filesys_lock);
+		struct file *opened = filesys_open(file);
+		lock_release(&filesys_lock);
+		if (opened == NULL) {
+			f->R.rax = -1;
+			break;
+		}
+		struct fd_entry *entry = malloc(sizeof *entry);
+		if (entry == NULL) {
+			file_close(opened);
+			f->R.rax = -1;
+			break;
+		}
+		entry->fd = t->next_fd;
+		entry->file = opened;
+		t->next_fd ++;
+		list_push_back(&t->fd_list, &entry->elem);
+		f->R.rax = entry->fd;
+		break;
+
 	}
 
 	case SYS_WRITE: {

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -105,6 +105,25 @@ syscall_handler (struct intr_frame *f UNUSED) {
 		break;
 	}
 	
+	case SYS_CLOSE: {
+		int fd = (int) f->R.rdi;
+		struct list_elem *e;
+		for (e = list_begin(&t->fd_list);
+			 e != list_end(&t->fd_list);
+			 e = list_next(e)) {
+			struct fd_entry *entry = list_entry(e, struct fd_entry, elem);
+			if (entry->fd == fd) {
+				lock_acquire(&filesys_lock);
+				file_close(entry->file);
+				lock_release(&filesys_lock);
+				list_remove(&entry->elem);
+				free(entry);
+				break;
+			}
+ 		}
+		break;
+	}
+	
 	case SYS_HALT: {
 		power_off();
 	}


### PR DESCRIPTION

## 변경 내용
- `SYS_CREATE`에서 `filesys_create()`를 호출하고 결과를 반환하도록 구현했습니다.
- `SYS_OPEN`에서 파일 open 성공 시 fd를 할당하고 `fd_list`에 열린 파일을 저장하도록 구현했습니다.
- `SYS_CLOSE`에서 fd를 찾아 파일을 닫고 fd entry를 제거하도록 구현했습니다.
- 프로세스별 fd 관리를 위해 `thread`에 `fd_list`, `next_fd`를 추가했습니다.
- 파일 시스템 작업 보호를 위해 전역 `filesys_lock`을 추가했습니다.

## 테스트
| 테스트 | 결과 |
| --- | --- |
| `halt` | PASS |
| `create-normal` | PASS |
| `create-empty` | PASS |
| `create-long` | PASS |
| `create-exists` | PASS |
| `open-normal` | PASS |
| `open-missing` | PASS |
| `open-empty` | PASS |
| `open-twice` | PASS |
| `close-normal` | PASS |
| `close-twice` | PASS |
| `close-bad-fd` | PASS |

## 리뷰 포인트
- `close`는 정책에 따라 invalid fd를 조용히 무시하도록 처리했습니다.
- bad pointer 계열 테스트는 이번 A 범위가 아니어서 본 PR의 핵심 구현 범위에 포함하지 않았습니다.

## PR 체크리스트
- [x] 관련 테스트를 직접 돌렸습니다.
- [x] 테스트 결과를 적었습니다.
- [x] 남은 리스크(리뷰 포인트)가 있으면 적었습니다.
