### PR TITLE
[process] wait/exec 구현 및 exec 예외처리 보완

### DIFF
--- a/pintos/include/threads/interrupt.h
+++ b/pintos/include/threads/interrupt.h
@@ -22,13 +22,13 @@ struct gp_registers {
 	uint64_t r13;
 	uint64_t r12;
 	uint64_t r11;
-	uint64_t r10;
+	uint64_t r10;  // 네번째 인자
 	uint64_t r9;
 	uint64_t r8;
-	uint64_t rsi;
-	uint64_t rdi;
+	uint64_t rsi;  // 두번째 인자
+	uint64_t rdi;  // 첫번째 인자
 	uint64_t rbp;
-	uint64_t rdx;
+	uint64_t rdx;  // 세번째 인자
 	uint64_t rcx;
 	uint64_t rbx;
 	uint64_t rax;
@@ -52,13 +52,13 @@ struct intr_frame {
 	uint64_t error_code;
 /* CPU가 푸시한다.
    인터럽트된 작업의 레지스터를 저장한 값이다. */
-	uintptr_t rip;
-	uint16_t cs;
+	uintptr_t rip;    // 인터럽트가 걸리기 직전에 실행하던 명령어 주소. 복귀하면 여기부터 실행
+	uint16_t cs;      // 코드 세그먼트 선택자. 사용자 모드 코드인지, 커널 코드인지 구분하는데 쓰임
 	uint16_t __pad5;
 	uint32_t __pad6;
-	uint64_t eflags;
-	uintptr_t rsp;
-	uint16_t ss;
+	uint64_t eflags;  // CPU 상태 플래그 레지스터, 인터럽트 허용 여부, 산술 결과 플래그, 방향 플래그 등이 들어있음
+	uintptr_t rsp;    // 인터럽트 직전의 스택 포인터, 복귀 시 원래 위치로 돌아가기 위해 사용
+	uint16_t ss;      // 스택 세그먼트 선택자, 사용자 모드와 커널 모드를 오갈 때 사용
 	uint16_t __pad7;
 	uint32_t __pad8;
 } __attribute__((packed));

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -104,6 +104,8 @@ struct  thread {
 	struct list_elem elem;              /* 리스트 원소. */
 	struct list_elem allelem;           /* 전체 리스트용 원소 */
 
+	uint64_t exit_status;               /* 종료 코드 */
+
 #ifdef USERPROG
 	/* `userprog/process.c`가 관리한다. */
 	uint64_t *pml4;                     /* 4단계 페이지 맵. */

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -5,6 +5,9 @@
 #include <list.h>
 #include <stdint.h>
 #include "threads/interrupt.h"
+#ifdef USERPROG
+struct child_status;
+#endif
 #ifdef VM
 #include "vm/vm.h"
 #endif
@@ -109,6 +112,8 @@ struct  thread {
 #ifdef USERPROG
 	/* `userprog/process.c`가 관리한다. */
 	uint64_t *pml4;                     /* 4단계 페이지 맵. */
+	struct list child_list;             /* 자식 스레드 리스트 */
+	struct child_status *my_status;      /* 본인의 스레드 상태 */
 #endif
 #ifdef VM
 	/* 스레드가 소유한 전체 가상 메모리용 테이블. */

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -67,11 +67,6 @@ process_create_initd (const char *file_name) {
 		return TID_ERROR;
 	}
 
-	if (!waited) {
-		sema_init(&wait_sema, 0);
-		waited = true;
-	}
-
 	/* Create a new thread to execute FILE_NAME. */
 	tid = thread_create (tmp, PRI_DEFAULT, initd, fn_copy);
 	if (tid == TID_ERROR)
@@ -220,16 +215,40 @@ process_exec (void *f_name) {
 	_if.cs = SEL_UCSEG;
 	_if.eflags = FLAG_IF | FLAG_MBS;
 
-	/* 먼저 현재 문맥을 정리한다. */
-	process_cleanup ();
+	/* 
+	 * 문맥 정리 후 적재하면 load 실패 시 데이터 손실 발생
+	 * load 되는지 확인 후, 문맥 정리
+	 * 
+	 * 기존 pml4 저장
+	 * load 시도
+	 * 실패 시 기존 pml4 복구, 새로 만든 pml4 폐기
+	 * 성공하면 기존 pml4 폐기, do_iret()
+	*/
+
+	struct thread *current = thread_current();
+	uint64_t *old_pml4 = current->pml4;
 
 	/* 그다음 바이너리를 적재한다. */
 	success = load (file_name, &_if);
 
 	/* 적재에 실패하면 종료한다. */
 	palloc_free_page (file_name);
-	if (!success)
+	if (!success) {
+		uint64_t *new_pml4 = current->pml4;
+		current->pml4 = old_pml4;
+
+		process_activate(current);
+
+		if (new_pml4 != NULL) {
+			pml4_destroy(new_pml4);
+		}
+
 		return -1;
+	}
+
+	if (old_pml4 != NULL) {
+		pml4_destroy(old_pml4);
+	}
 
 	/* 전환된 프로세스를 시작한다. */
 	do_iret (&_if);
@@ -258,7 +277,6 @@ process_wait (tid_t child_tid) {
 	 * child 상태 리스트에서 제거 및 해제
 	 * exit_status 반환
 	*/
-
 
 	struct thread *cur = thread_current();
 	struct list *child_list = &cur->child_list;

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -29,14 +29,13 @@ static void initd (void *f_name);
 static void __do_fork (void *);
 static bool parse_filename(const char *file_name, char *tmp, size_t tmp_size);
 
-static struct semaphore wait_sema;
-static bool waited;
-static int exit_status;
-
 /* initd와 그 외 프로세스에서 공통으로 사용하는 초기화 함수. */
 static void
 process_init (void) {
 	struct thread *current = thread_current ();
+
+	list_init(&current->child_list);
+	current->my_status = NULL;
 }
 
 /* FILE_NAME에서 읽어들인 첫 번째 사용자 영역 프로그램 "initd"를 시작한다.
@@ -246,12 +245,53 @@ process_exec (void *f_name) {
  *
  * 이 함수는 problem 2-2에서 구현한다. 현재는 아무 일도 하지 않는다. */
 int
-process_wait (tid_t child_tid UNUSED) {
+process_wait (tid_t child_tid) {
 	/* XXX: Hint) The pintos exit if process_wait (initd), we recommend you
 	 * XXX:       to add infinite loop here before
 	 * XXX:       implementing the process_wait. */
-	sema_down(&wait_sema);
-	return exit_status;
+
+	/*
+	 * 현재 스레드의 child list 확인
+	 * child tid 찾기 - 없으면 -1, wait 했으면 -1
+	 * 안 죽었으면 waited -> sema_down
+	 * 죽었으면 exit_status 읽기
+	 * child 상태 리스트에서 제거 및 해제
+	 * exit_status 반환
+	*/
+
+
+	struct thread *cur = thread_current();
+	struct list *child_list = &cur->child_list;
+	struct child_status *child = NULL;
+
+	struct list_elem *e;
+	for (e = list_begin(child_list); e != list_end(child_list); e = list_next(e)) {
+		struct child_status *tmp = list_entry(e, struct child_status, elem);
+		if (tmp->tid == child_tid) {
+			child = tmp;
+			break;
+		}
+	}
+
+	if (child == NULL) {
+		return -1;
+	}
+
+	if (child->waited) {
+		return -1;
+	}
+
+	child->waited = true;
+
+	if (!child->exited) {
+		sema_down(&child->wait_sema);
+	}
+	int status = child->exit_status;
+
+	list_remove(&child->elem);
+	free(child);
+
+	return status;
 }
 
 /* 프로세스를 종료한다. 이 함수는 thread_exit()에서 호출된다. */
@@ -271,16 +311,14 @@ process_exit (void) {
 	 * 주소 공간 정리
 	*/
 	printf ("%s: exit(%d)\n", thread_name(), (int) curr->exit_status);
-	exit_status = curr->exit_status;
-	sema_up(&wait_sema);
 	
-	// struct child_status *child = curr->my_status;
-	// child->exit_status = curr->exit_status;
-	// child->exited = true;
+	struct child_status *child = curr->my_status;
 
-	// if (child->waited) {
-	// 	sema_up(&child->wait_sema);
-	// }
+	if (child != NULL) {
+		child->exit_status = curr->exit_status;
+		child->exited = true;
+		sema_up(&child->wait_sema);
+	}
 
 	process_cleanup ();
 }

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -17,6 +17,7 @@
 #include "threads/thread.h"
 #include "threads/mmu.h"
 #include "threads/vaddr.h"
+#include "threads/synch.h"
 #include "intrinsic.h"
 #ifdef VM
 #include "vm/vm.h"
@@ -26,6 +27,11 @@ static void process_cleanup (void);
 static bool load (const char *file_name, struct intr_frame *if_);
 static void initd (void *f_name);
 static void __do_fork (void *);
+static bool parse_filename(const char *file_name, char *tmp, size_t tmp_size);
+
+static struct semaphore wait_sema;
+static bool waited;
+static int exit_status;
 
 /* initd와 그 외 프로세스에서 공통으로 사용하는 초기화 함수. */
 static void
@@ -50,7 +56,6 @@ process_create_initd (const char *file_name) {
 		return TID_ERROR;
 	strlcpy (fn_copy, file_name, PGSIZE);
 
-
 	char *tmp = palloc_get_page(0);
 	if (tmp == NULL) {
 		palloc_free_page(fn_copy);
@@ -69,10 +74,26 @@ process_create_initd (const char *file_name) {
 	}
 
 	/* Create a new thread to execute FILE_NAME. */
-	tid = thread_create (file_name, PRI_DEFAULT, initd, fn_copy);
+	tid = thread_create (tmp, PRI_DEFAULT, initd, fn_copy);
 	if (tid == TID_ERROR)
 		palloc_free_page (fn_copy);
+	
+	palloc_free_page(tmp);
+
 	return tid;
+}
+
+static bool parse_filename(const char *file_name, char *tmp, size_t tmp_size) {
+	if (tmp == NULL || file_name == NULL) {
+		return false;
+	}
+
+	strlcpy(tmp, file_name, tmp_size);
+
+	char *save_token;
+	char *token = strtok_r(tmp, " ", &save_token);
+	
+	return token != NULL;
 }
 
 /* A thread function that launches first user process. */
@@ -175,6 +196,16 @@ error:
 	thread_exit ();
 }
 
+// 자식 스레드 상태
+struct child_status {
+	tid_t tid;                     /* 자식 스레드 tid */
+	int exit_status;               /* 자식이 exit()할 때 남긴 종료 코드 */
+	bool exited;                   /* 자식이 종료했는지 여부 */
+	bool waited;                   /* 부모가 자식에 대해서 wait() 했는지 여부 */
+	struct semaphore wait_sema;    /* 부모가 자식 종료를 기다릴 때 사용하는 세마포어 */
+	struct list_elem elem;         /* child list 리스트 노드 */
+};
+
 /* Switch the current execution context to the f_name.
  * Returns -1 on fail. */
 int
@@ -219,7 +250,8 @@ process_wait (tid_t child_tid UNUSED) {
 	/* XXX: Hint) The pintos exit if process_wait (initd), we recommend you
 	 * XXX:       to add infinite loop here before
 	 * XXX:       implementing the process_wait. */
-	return -1;
+	sema_down(&wait_sema);
+	return exit_status;
 }
 
 /* 프로세스를 종료한다. 이 함수는 thread_exit()에서 호출된다. */
@@ -349,6 +381,8 @@ static bool load_segment (struct file *file, off_t ofs, uint8_t *upage,
 		uint32_t read_bytes, uint32_t zero_bytes,
 		bool writable);
 
+#define MAX_ARGC 63
+
 /* Loads an ELF executable from FILE_NAME into the current thread.
  * Stores the executable's entry point into *RIP
  * and its initial stack pointer into *RSP.
@@ -361,6 +395,29 @@ load (const char *file_name, struct intr_frame *if_) {
 	off_t file_ofs;
 	bool success = false;
 	int i;
+	/* file_name 파싱을 위한 copy 만들기 */
+	char *file_name_copy = palloc_get_page(0);
+	if (file_name_copy == NULL) {
+		goto done;
+	}
+	strlcpy(file_name_copy, file_name, PGSIZE);
+	/* NULL까지 반복하여 argv 만들기 */
+	char *argv[MAX_ARGC + 1];
+	char *save_ptr;
+	char *token = strtok_r(file_name_copy, " ", &save_ptr);
+	if (token == NULL) {
+		goto done;
+	}
+	int argc = 0;
+	while (token != NULL) {
+		if (argc >= MAX_ARGC) {
+			goto done;
+		}
+		argv[argc] = token;
+		argc++;
+		token = strtok_r(NULL, " ", &save_ptr);
+	}
+	argv[argc] = NULL; // 배열의 마지막 값은 NULL로 설정
 
 	/* 페이지 디렉터리를 할당하고 활성화한다. */
 	t->pml4 = pml4_create ();
@@ -369,9 +426,9 @@ load (const char *file_name, struct intr_frame *if_) {
 	process_activate (thread_current ());
 
 	/* Open executable file. */
-	file = filesys_open (file_name);
+	file = filesys_open (argv[0]);
 	if (file == NULL) {
-		printf ("load: %s: open failed\n", file_name);
+		printf ("load: %s: open failed\n", argv[0]);
 		goto done;
 	}
 
@@ -448,13 +505,59 @@ load (const char *file_name, struct intr_frame *if_) {
 	if_->rip = ehdr.e_entry;
 
 	/* TODO: Your code goes here.
-	 * TODO: Implement argument passing (see project2/argument_passing.html). */
+	/* TODO: Implement argument passing (see project2/argument_passing.html). */
+	/* 스택에 토큰 올리기 */
+	// 스택 맨 위에 명령줄 문자열 삽입한다
+	char *arg_addr[MAX_ARGC];
+	int j = 0;
 
+	while (argv[j] != NULL) {
+		size_t str_len = strlen(argv[j]) + 1;
+
+		if_->rsp -= str_len;
+		memcpy((void *)if_->rsp, argv[j], str_len);
+
+		arg_addr[j] = (char *)if_->rsp;
+		j++;
+	}
+
+	// 스택 주소 시작점을 word 크기로 정렬한다
+	while (if_->rsp % 8 != 0) {
+		if_->rsp--;
+		*(uint8_t *)if_->rsp = 0;
+	}
+
+	// 맨 처음 NULL 삽입
+	if_->rsp -= 8;
+	char *null_ptr = NULL;
+	memcpy((void *)if_->rsp, &null_ptr, sizeof(null_ptr));
+
+
+	// rsp를 늘리고 agrv 역순으로 삽입 반복 until argc == 0
+	while (j > 0) {
+		j--;
+		if_->rsp -= 8;
+		memcpy((void *)if_->rsp, &arg_addr[j], sizeof(arg_addr[j]));
+	}
+
+	// argv 시작 주소
+	char **argv_addr = (char **) if_->rsp;
+
+	// 마지막에 가짜 return 주소 삽입
+	char *fake_rex = 0;
+	if_->rsp -= sizeof(fake_rex);
+	memcpy((void *)if_->rsp, &fake_rex, sizeof(fake_rex));
+
+	if_->R.rdi = argc;
+	if_->R.rsi = argv_addr;
 	success = true;
 
 done:
 	/* We arrive here whether the load is successful or not. */
-	file_close (file);
+	if (file != NULL) {
+		file_close (file);
+	}
+	palloc_free_page(file_name_copy);
 	return success;
 }
 

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -70,15 +70,13 @@ syscall_handler (struct intr_frame *f UNUSED) {
 		power_off();
 	}
 
-	case SYS_EXEC: {
-		/*
-		 * cmd_line 유효성 확인
-		 * 커널 페이지 하나 할당
-		 * 사용자 문자열을 kbuf로 복사
-		 * 실패 시 -1 반환
-		 * 성공하면 process_exec()
-		*/
+	case SYS_WAIT: {
+		tid_t child_tid = (tid_t)f->R.rdi;
+		f->R.rax = process_wait(child_tid);
+		break;
+	}
 
+	case SYS_EXEC: {
 		const char *cmd_line = (const char *)f->R.rdi;
 		char *kbuf;
 
@@ -107,20 +105,24 @@ static bool copy_in_string (char *buf, const char *command, size_t size) {
     size_t i;
     struct thread *t = thread_current ();
 
-    if (command == NULL)
+    if (command == NULL) {
         return false;
+	}
 
     for (i = 0; i < size; i++) {
         const char *uaddr = command + i;
 
-        if (!is_user_vaddr (uaddr))
+        if (!is_user_vaddr (uaddr)) {
             return false;
-        if (pml4_get_page(t->pml4, uaddr) == NULL)
+		}
+        if (pml4_get_page(t->pml4, uaddr) == NULL) {
             return false;
+		}
 
         buf[i] = *uaddr;
-        if (buf[i] == '\0')
+        if (buf[i] == '\0') {
             return true;
+		}
     }
 
     buf[size - 1] = '\0';

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -9,10 +9,12 @@
 #include "threads/flags.h"
 #include "threads/init.h"
 #include "threads/palloc.h"
+#include "threads/mmu.h"
 #include "intrinsic.h"
 
 void syscall_entry (void);
 void syscall_handler (struct intr_frame *);
+static bool copy_in_string (char *buf, const char *command, size_t size);
 
 /* 시스템 호출.
  *
@@ -86,7 +88,12 @@ syscall_handler (struct intr_frame *f UNUSED) {
 			break;
 		}
 
-		strlcpy(kbuf, cmd_line, PGSIZE);
+		if (!copy_in_string(kbuf, cmd_line, PGSIZE)) {
+			palloc_free_page(kbuf);
+			t->exit_status = -1;
+    		thread_exit();
+		}
+
 		f->R.rax = process_exec(kbuf);
 		break;
 	}
@@ -94,4 +101,28 @@ syscall_handler (struct intr_frame *f UNUSED) {
 	default:
 		break;
 	}
+}
+
+static bool copy_in_string (char *buf, const char *command, size_t size) {
+    size_t i;
+    struct thread *t = thread_current ();
+
+    if (command == NULL)
+        return false;
+
+    for (i = 0; i < size; i++) {
+        const char *uaddr = command + i;
+
+        if (!is_user_vaddr (uaddr))
+            return false;
+        if (pml4_get_page(t->pml4, uaddr) == NULL)
+            return false;
+
+        buf[i] = *uaddr;
+        if (buf[i] == '\0')
+            return true;
+    }
+
+    buf[size - 1] = '\0';
+    return true;
 }

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -5,7 +5,9 @@
 #include "threads/thread.h"
 #include "threads/loader.h"
 #include "userprog/gdt.h"
+#include "userprog/process.h"
 #include "threads/flags.h"
+#include "threads/init.h"
 #include "intrinsic.h"
 
 void syscall_entry (void);
@@ -68,5 +70,4 @@ syscall_handler (struct intr_frame *f UNUSED) {
 	default:
 		break;
 	}
-
 }

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -8,6 +8,7 @@
 #include "userprog/process.h"
 #include "threads/flags.h"
 #include "threads/init.h"
+#include "threads/palloc.h"
 #include "intrinsic.h"
 
 void syscall_entry (void);
@@ -65,6 +66,29 @@ syscall_handler (struct intr_frame *f UNUSED) {
 	
 	case SYS_HALT: {
 		power_off();
+	}
+
+	case SYS_EXEC: {
+		/*
+		 * cmd_line 유효성 확인
+		 * 커널 페이지 하나 할당
+		 * 사용자 문자열을 kbuf로 복사
+		 * 실패 시 -1 반환
+		 * 성공하면 process_exec()
+		*/
+
+		const char *cmd_line = (const char *)f->R.rdi;
+		char *kbuf;
+
+		kbuf = palloc_get_page(0);
+		if (kbuf == NULL) {
+			f->R.rax = -1;
+			break;
+		}
+
+		strlcpy(kbuf, cmd_line, PGSIZE);
+		f->R.rax = process_exec(kbuf);
+		break;
 	}
 	
 	default:

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -50,7 +50,7 @@ syscall_handler (struct intr_frame *f UNUSED) {
 	{
 	case SYS_EXIT: {
 		uint64_t status = f->R.rdi;
-		//t->exit_status = status;
+		t->exit_status = status;
 		thread_exit ();
 		break;
 	}


### PR DESCRIPTION
## 변경 내용
-
- `SYS_WAIT`, `SYS_EXEC` 시스템콜을 연결하고, `exec` 인자 복사 과정에 유저 포인터 검증 로직을 추가했습니다.
- 부모-자식 상태를 기준으로 `wait`, `exit_status` 회수, 중복 `wait` 방지 흐름을 구현했습니다.
- `process_exec()`에서 load 실패 시 기존 주소 공간을 복구하도록 예외 처리를 보완했습니다.

## 테스트
| 테스트 | 결과 |
| --- | --- |
| `userprog 테스트` | 미실행 |
| `wait/exec 관련 케이스` | 미검증 |

## 리뷰 포인트
-
- 아직 테스트로 검증하지 못해 `wait/exec` 경계 케이스에서 동기화나 상태 정리 누락이 없는지 확인 부탁드립니다.
- `exec` 실패 시 메모리 정리와 기존 문맥 복구가 충분한지 같이 봐주시면 좋겠습니다.

## PR 체크리스트
- [ ] 관련 테스트를 직접 돌렸습니다.
- [x] 테스트 결과를 적었습니다.
- [x] 남은 리스크(리뷰 포인트)가 있으면 적었습니다.
