### PR TITLE
[syscall] read 시스템콜 구현

### DIFF
--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -82,6 +82,13 @@ typedef int tid_t;
  * 원소가 될 수도 있다. 이 두 용도가 동시에 겹치지 않는 이유는
  * 준비 상태의 스레드만 실행 큐에 있고, 블록 상태의 스레드만
  * 세마포어 대기 리스트에 있기 때문이다. */
+struct file;
+struct fd_entry {
+	int fd;                    /* fd 번호 */
+	struct file *file;         /* 실제 열린 파일 객체 */
+	struct list_elem elem;     /* fd_list에 연결되기 위한 노드 */
+};
+
 struct  thread {
 	/* `thread.c`가 관리한다. */
 	tid_t tid;                          /* 스레드 식별자. */
@@ -109,6 +116,8 @@ struct  thread {
 #ifdef USERPROG
 	/* `userprog/process.c`가 관리한다. */
 	uint64_t *pml4;                     /* 4단계 페이지 맵. */
+	struct list fd_list;	// 현재 프로세스가 열어둔 파일 목록
+	int next_fd;	// Open 때 줄 번호
 #endif
 #ifdef VM
 	/* 스레드가 소유한 전체 가상 메모리용 테이블. */

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -626,6 +626,10 @@ init_thread(struct thread *t, const char *name, int priority)
 	t->origin_priority = priority;
 	t->wait_on_lock = NULL;
 	list_init(&t->donations);
+	#ifdef USERPROG
+	list_init(&t->fd_list);
+	t->next_fd = 2;
+	#endif
 
 	t->nice = 0;
 	t->recent_cpu = 0;

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -27,24 +27,24 @@ static bool load (const char *file_name, struct intr_frame *if_);
 static void initd (void *f_name);
 static void __do_fork (void *);
 
-/* General process initializer for initd and other process. */
+/* initd와 그 외 프로세스에서 공통으로 사용하는 초기화 함수. */
 static void
 process_init (void) {
 	struct thread *current = thread_current ();
 }
 
-/* Starts the first userland program, called "initd", loaded from FILE_NAME.
- * The new thread may be scheduled (and may even exit)
- * before process_create_initd() returns. Returns the initd's
- * thread id, or TID_ERROR if the thread cannot be created.
- * Notice that THIS SHOULD BE CALLED ONCE. */
+/* FILE_NAME에서 읽어들인 첫 번째 사용자 영역 프로그램 "initd"를 시작한다.
+ * process_create_initd()가 반환되기 전에 새 스레드가 스케줄될 수도 있고,
+ * 심지어 종료될 수도 있다. 성공하면 initd의 스레드 ID를 반환하고,
+ * 스레드를 만들 수 없으면 TID_ERROR를 반환한다.
+ * 이 함수는 반드시 한 번만 호출해야 한다. */
 tid_t
 process_create_initd (const char *file_name) {
 	char *fn_copy;
 	tid_t tid;
 
-	/* Make a copy of FILE_NAME.
-	 * Otherwise there's a race between the caller and load(). */
+	/* FILE_NAME의 사본을 만든다.
+	 * 그렇지 않으면 호출자와 load() 사이에 경쟁 상태가 생긴다. */
 	fn_copy = palloc_get_page (0);
 	if (fn_copy == NULL)
 		return TID_ERROR;
@@ -71,18 +71,18 @@ initd (void *f_name) {
 	NOT_REACHED ();
 }
 
-/* Clones the current process as `name`. Returns the new process's thread id, or
- * TID_ERROR if the thread cannot be created. */
+/* 현재 프로세스를 `name`이라는 이름으로 복제한다. 성공하면 새 프로세스의
+ * 스레드 ID를 반환하고, 스레드를 만들 수 없으면 TID_ERROR를 반환한다. */
 tid_t
 process_fork (const char *name, struct intr_frame *if_ UNUSED) {
-	/* Clone current thread to new thread.*/
+	/* 현재 스레드를 새 스레드로 복제한다. */
 	return thread_create (name,
 			PRI_DEFAULT, __do_fork, thread_current ());
 }
 
 #ifndef VM
-/* Duplicate the parent's address space by passing this function to the
- * pml4_for_each. This is only for the project 2. */
+/* 이 함수를 pml4_for_each에 넘겨 부모의 주소 공간을 복제한다.
+ * project 2에서만 사용한다. */
 static bool
 duplicate_pte (uint64_t *pte, void *va, void *aux) {
 	struct thread *current = thread_current ();
@@ -91,44 +91,43 @@ duplicate_pte (uint64_t *pte, void *va, void *aux) {
 	void *newpage;
 	bool writable;
 
-	/* 1. TODO: If the parent_page is kernel page, then return immediately. */
+	/* 1. TODO: parent_page가 커널 페이지라면 즉시 반환한다. */
 
-	/* 2. Resolve VA from the parent's page map level 4. */
+	/* 2. 부모의 페이지 맵 레벨 4에서 VA를 찾는다. */
 	parent_page = pml4_get_page (parent->pml4, va);
 
-	/* 3. TODO: Allocate new PAL_USER page for the child and set result to
-	 *    TODO: NEWPAGE. */
+	/* 3. TODO: 자식용 새 PAL_USER 페이지를 할당하고 결과를
+	 *    TODO: NEWPAGE에 저장한다. */
 
-	/* 4. TODO: Duplicate parent's page to the new page and
-	 *    TODO: check whether parent's page is writable or not (set WRITABLE
-	 *    TODO: according to the result). */
+	/* 4. TODO: 부모 페이지 내용을 새 페이지로 복사하고,
+	 *    TODO: 부모 페이지의 쓰기 가능 여부를 확인해 그 결과에 따라
+	 *    TODO: WRITABLE을 설정한다. */
 
-	/* 5. Add new page to child's page table at address VA with WRITABLE
-	 *    permission. */
+	/* 5. VA 주소에 WRITABLE 권한으로 새 페이지를 자식의 페이지 테이블에
+	 *    추가한다. */
 	if (!pml4_set_page (current->pml4, va, newpage, writable)) {
-		/* 6. TODO: if fail to insert page, do error handling. */
+		/* 6. TODO: 페이지 삽입에 실패하면 오류 처리를 한다. */
 	}
 	return true;
 }
 #endif
 
-/* A thread function that copies parent's execution context.
- * Hint) parent->tf does not hold the userland context of the process.
- *       That is, you are required to pass second argument of process_fork to
- *       this function. */
+/* 부모의 실행 문맥을 복사하는 스레드 함수.
+ * 힌트) parent->tf에는 프로세스의 사용자 영역 문맥이 들어 있지 않다.
+ *       즉, process_fork의 두 번째 인자를 이 함수로 전달해야 한다. */
 static void
 __do_fork (void *aux) {
 	struct intr_frame if_;
 	struct thread *parent = (struct thread *) aux;
 	struct thread *current = thread_current ();
-	/* TODO: somehow pass the parent_if. (i.e. process_fork()'s if_) */
+	/* TODO: parent_if를 적절히 전달한다. (즉, process_fork()의 if_) */
 	struct intr_frame *parent_if;
 	bool succ = true;
 
-	/* 1. Read the cpu context to local stack. */
+	/* 1. CPU 문맥을 로컬 스택으로 읽어온다. */
 	memcpy (&if_, parent_if, sizeof (struct intr_frame));
 
-	/* 2. Duplicate PT */
+	/* 2. 페이지 테이블을 복제한다. */
 	current->pml4 = pml4_create();
 	if (current->pml4 == NULL)
 		goto error;
@@ -143,15 +142,15 @@ __do_fork (void *aux) {
 		goto error;
 #endif
 
-	/* TODO: Your code goes here.
-	 * TODO: Hint) To duplicate the file object, use `file_duplicate`
-	 * TODO:       in include/filesys/file.h. Note that parent should not return
-	 * TODO:       from the fork() until this function successfully duplicates
-	 * TODO:       the resources of parent.*/
+	/* TODO: 여기에 코드를 작성한다.
+	 * TODO: 힌트) 파일 객체를 복제하려면 include/filesys/file.h의
+	 * TODO:       `file_duplicate`를 사용한다. 이 함수가 부모의 자원을
+	 * TODO:       성공적으로 복제하기 전까지 부모는 fork()에서 반환하면
+	 * TODO:       안 된다. */
 
 	process_init ();
 
-	/* Finally, switch to the newly created process. */
+	/* 마지막으로 새로 만들어진 프로세스로 전환한다. */
 	if (succ)
 		do_iret (&if_);
 error:
@@ -165,40 +164,38 @@ process_exec (void *f_name) {
 	char *file_name = f_name;
 	bool success;
 
-	/* We cannot use the intr_frame in the thread structure.
-	 * This is because when current thread rescheduled,
-	 * it stores the execution information to the member. */
+	/* thread 구조체 안의 intr_frame은 사용할 수 없다.
+	 * 현재 스레드가 다시 스케줄될 때 해당 멤버에 실행 정보가 저장되기
+	 * 때문이다. */
 	struct intr_frame _if; 
 	_if.ds = _if.es = _if.ss = SEL_UDSEG;
 	_if.cs = SEL_UCSEG;
 	_if.eflags = FLAG_IF | FLAG_MBS;
 
-	/* We first kill the current context */
+	/* 먼저 현재 문맥을 정리한다. */
 	process_cleanup ();
 
-	/* And then load the binary */
+	/* 그다음 바이너리를 적재한다. */
 	success = load (file_name, &_if);
 
-	/* If load failed, quit. */
+	/* 적재에 실패하면 종료한다. */
 	palloc_free_page (file_name);
 	if (!success)
 		return -1;
 
-	/* Start switched process. */
+	/* 전환된 프로세스를 시작한다. */
 	do_iret (&_if);
 	NOT_REACHED ();
 }
 
 
-/* Waits for thread TID to die and returns its exit status.  If
- * it was terminated by the kernel (i.e. killed due to an
- * exception), returns -1.  If TID is invalid or if it was not a
- * child of the calling process, or if process_wait() has already
- * been successfully called for the given TID, returns -1
- * immediately, without waiting.
+/* 스레드 TID가 종료될 때까지 기다렸다가 종료 상태를 반환한다. 커널에 의해
+ * 종료된 경우(즉, 예외 때문에 죽은 경우)에는 -1을 반환한다. TID가
+ * 잘못되었거나, 호출한 프로세스의 자식이 아니거나, 해당 TID에 대해
+ * process_wait()가 이미 성공적으로 호출된 적이 있다면 기다리지 않고 즉시
+ * -1을 반환한다.
  *
- * This function will be implemented in problem 2-2.  For now, it
- * does nothing. */
+ * 이 함수는 problem 2-2에서 구현한다. 현재는 아무 일도 하지 않는다. */
 int
 process_wait (tid_t child_tid UNUSED) {
 	/* XXX: Hint) The pintos exit if process_wait (initd), we recommend you
@@ -207,19 +204,19 @@ process_wait (tid_t child_tid UNUSED) {
 	return -1;
 }
 
-/* Exit the process. This function is called by thread_exit (). */
+/* 프로세스를 종료한다. 이 함수는 thread_exit()에서 호출된다. */
 void
 process_exit (void) {
 	struct thread *curr = thread_current ();
-	/* TODO: Your code goes here.
-	 * TODO: Implement process termination message (see
-	 * TODO: project2/process_termination.html).
-	 * TODO: We recommend you to implement process resource cleanup here. */
+	/* TODO: 여기에 코드를 작성한다.
+	 * TODO: 프로세스 종료 메시지를 구현한다
+	 * TODO: (project2/process_termination.html 참고).
+	 * TODO: 프로세스 자원 정리도 여기서 구현하는 것을 권장한다. */
 
 	process_cleanup ();
 }
 
-/* Free the current process's resources. */
+/* 현재 프로세스의 자원을 해제한다. */
 static void
 process_cleanup (void) {
 	struct thread *curr = thread_current ();
@@ -229,55 +226,54 @@ process_cleanup (void) {
 #endif
 
 	uint64_t *pml4;
-	/* Destroy the current process's page directory and switch back
-	 * to the kernel-only page directory. */
+	/* 현재 프로세스의 페이지 디렉터리를 파괴하고 커널 전용 페이지
+	 * 디렉터리로 돌아간다. */
 	pml4 = curr->pml4;
 	if (pml4 != NULL) {
-		/* Correct ordering here is crucial.  We must set
-		 * cur->pagedir to NULL before switching page directories,
-		 * so that a timer interrupt can't switch back to the
-		 * process page directory.  We must activate the base page
-		 * directory before destroying the process's page
-		 * directory, or our active page directory will be one
-		 * that's been freed (and cleared). */
+		/* 여기서는 순서가 매우 중요하다. 타이머 인터럽트가 다시
+		 * 프로세스 페이지 디렉터리로 전환하지 못하게, 페이지 디렉터리를
+		 * 바꾸기 전에 cur->pagedir을 NULL로 설정해야 한다. 또한
+		 * 프로세스 페이지 디렉터리를 파괴하기 전에 기본 페이지
+		 * 디렉터리를 활성화해야 한다. 그렇지 않으면 현재 활성 페이지
+		 * 디렉터리가 이미 해제된(그리고 비워진) 것이 된다. */
 		curr->pml4 = NULL;
 		pml4_activate (NULL);
 		pml4_destroy (pml4);
 	}
 }
 
-/* Sets up the CPU for running user code in the nest thread.
- * This function is called on every context switch. */
+/* 다음 스레드에서 사용자 코드를 실행할 수 있도록 CPU를 설정한다.
+ * 이 함수는 문맥 전환이 일어날 때마다 호출된다. */
 void
 process_activate (struct thread *next) {
-	/* Activate thread's page tables. */
+	/* 스레드의 페이지 테이블을 활성화한다. */
 	pml4_activate (next->pml4);
 
-	/* Set thread's kernel stack for use in processing interrupts. */
+	/* 인터럽트 처리에 사용할 스레드의 커널 스택을 설정한다. */
 	tss_update (next);
 }
 
-/* We load ELF binaries.  The following definitions are taken
- * from the ELF specification, [ELF1], more-or-less verbatim.  */
+/* ELF 바이너리를 적재한다. 아래 정의는 [ELF1]의 ELF 명세를 거의 그대로
+ * 가져온 것이다. */
 
-/* ELF types.  See [ELF1] 1-2. */
+/* ELF 타입. [ELF1] 1-2 참고. */
 #define EI_NIDENT 16
 
-#define PT_NULL    0            /* Ignore. */
-#define PT_LOAD    1            /* Loadable segment. */
-#define PT_DYNAMIC 2            /* Dynamic linking info. */
-#define PT_INTERP  3            /* Name of dynamic loader. */
-#define PT_NOTE    4            /* Auxiliary info. */
-#define PT_SHLIB   5            /* Reserved. */
-#define PT_PHDR    6            /* Program header table. */
+#define PT_NULL    0            /* 무시. */
+#define PT_LOAD    1            /* 적재 가능한 세그먼트. */
+#define PT_DYNAMIC 2            /* 동적 링크 정보. */
+#define PT_INTERP  3            /* 동적 로더 이름. */
+#define PT_NOTE    4            /* 보조 정보. */
+#define PT_SHLIB   5            /* 예약됨. */
+#define PT_PHDR    6            /* 프로그램 헤더 테이블. */
 #define PT_STACK   0x6474e551   /* Stack segment. */
 
-#define PF_X 1          /* Executable. */
-#define PF_W 2          /* Writable. */
-#define PF_R 4          /* Readable. */
+#define PF_X 1          /* 실행 가능. */
+#define PF_W 2          /* 쓰기 가능. */
+#define PF_R 4          /* 읽기 가능. */
 
-/* Executable header.  See [ELF1] 1-4 to 1-8.
- * This appears at the very beginning of an ELF binary. */
+/* 실행 파일 헤더. [ELF1] 1-4~1-8 참고.
+ * ELF 바이너리의 맨 앞부분에 위치한다. */
 struct ELF64_hdr {
 	unsigned char e_ident[EI_NIDENT];
 	uint16_t e_type;
@@ -306,7 +302,7 @@ struct ELF64_PHDR {
 	uint64_t p_align;
 };
 
-/* Abbreviations */
+/* 약어 */
 #define ELF ELF64_hdr
 #define Phdr ELF64_PHDR
 
@@ -349,7 +345,7 @@ load (const char *file_name, struct intr_frame *if_) {
 	}
 	argv[argc] = NULL; // 배열의 마지막 값은 NULL로 설정
 
-	/* Allocate and activate page directory. */
+	/* 페이지 디렉터리를 할당하고 활성화한다. */
 	t->pml4 = pml4_create ();
 	if (t->pml4 == NULL)
 		goto done;
@@ -362,11 +358,11 @@ load (const char *file_name, struct intr_frame *if_) {
 		goto done;
 	}
 
-	/* Read and verify executable header. */
+	/* 실행 파일 헤더를 읽고 검증한다. */
 	if (file_read (file, &ehdr, sizeof ehdr) != sizeof ehdr
 			|| memcmp (ehdr.e_ident, "\177ELF\2\1\1", 7)
 			|| ehdr.e_type != 2
-			|| ehdr.e_machine != 0x3E // amd64
+			|| ehdr.e_machine != 0x3E // amd64 아키텍처
 			|| ehdr.e_version != 1
 			|| ehdr.e_phentsize != sizeof (struct Phdr)
 			|| ehdr.e_phnum > 1024) {
@@ -374,7 +370,7 @@ load (const char *file_name, struct intr_frame *if_) {
 		goto done;
 	}
 
-	/* Read program headers. */
+	/* 프로그램 헤더를 읽는다. */
 	file_ofs = ehdr.e_phoff;
 	for (i = 0; i < ehdr.e_phnum; i++) {
 		struct Phdr phdr;
@@ -392,7 +388,7 @@ load (const char *file_name, struct intr_frame *if_) {
 			case PT_PHDR:
 			case PT_STACK:
 			default:
-				/* Ignore this segment. */
+				/* 이 세그먼트는 무시한다. */
 				break;
 			case PT_DYNAMIC:
 			case PT_INTERP:
@@ -406,14 +402,14 @@ load (const char *file_name, struct intr_frame *if_) {
 					uint64_t page_offset = phdr.p_vaddr & PGMASK;
 					uint32_t read_bytes, zero_bytes;
 					if (phdr.p_filesz > 0) {
-						/* Normal segment.
-						 * Read initial part from disk and zero the rest. */
+						/* 일반 세그먼트.
+						 * 앞부분은 디스크에서 읽고 나머지는 0으로 채운다. */
 						read_bytes = page_offset + phdr.p_filesz;
 						zero_bytes = (ROUND_UP (page_offset + phdr.p_memsz, PGSIZE)
 								- read_bytes);
 					} else {
-						/* Entirely zero.
-						 * Don't read anything from disk. */
+						/* 전부 0으로 채워진 세그먼트.
+						 * 디스크에서는 아무것도 읽지 않는다. */
 						read_bytes = 0;
 						zero_bytes = ROUND_UP (page_offset + phdr.p_memsz, PGSIZE);
 					}
@@ -427,11 +423,11 @@ load (const char *file_name, struct intr_frame *if_) {
 		}
 	}
 
-	/* Set up stack. */
+	/* 스택을 설정한다. */
 	if (!setup_stack (if_))
 		goto done;
 
-	/* Start address. */
+	/* 시작 주소를 설정한다. */
 	if_->rip = ehdr.e_entry;
 
 	/* TODO: Your code goes here.
@@ -492,72 +488,69 @@ done:
 }
 
 
-/* Checks whether PHDR describes a valid, loadable segment in
- * FILE and returns true if so, false otherwise. */
+/* PHDR이 FILE 안의 유효하고 적재 가능한 세그먼트를 설명하는지 검사한다.
+ * 맞으면 true, 아니면 false를 반환한다. */
 static bool
 validate_segment (const struct Phdr *phdr, struct file *file) {
-	/* p_offset and p_vaddr must have the same page offset. */
+	/* p_offset과 p_vaddr은 같은 페이지 오프셋을 가져야 한다. */
 	if ((phdr->p_offset & PGMASK) != (phdr->p_vaddr & PGMASK))
 		return false;
 
-	/* p_offset must point within FILE. */
+	/* p_offset은 FILE 내부를 가리켜야 한다. */
 	if (phdr->p_offset > (uint64_t) file_length (file))
 		return false;
 
-	/* p_memsz must be at least as big as p_filesz. */
+	/* p_memsz는 최소한 p_filesz 이상이어야 한다. */
 	if (phdr->p_memsz < phdr->p_filesz)
 		return false;
 
-	/* The segment must not be empty. */
+	/* 세그먼트는 비어 있으면 안 된다. */
 	if (phdr->p_memsz == 0)
 		return false;
 
-	/* The virtual memory region must both start and end within the
-	   user address space range. */
+	/* 가상 메모리 영역의 시작과 끝은 모두 사용자 주소 공간 범위 안에
+	   있어야 한다. */
 	if (!is_user_vaddr ((void *) phdr->p_vaddr))
 		return false;
 	if (!is_user_vaddr ((void *) (phdr->p_vaddr + phdr->p_memsz)))
 		return false;
 
-	/* The region cannot "wrap around" across the kernel virtual
-	   address space. */
+	/* 이 영역이 커널 가상 주소 공간을 가로질러 "되감기"처럼
+	   넘쳐서는 안 된다. */
 	if (phdr->p_vaddr + phdr->p_memsz < phdr->p_vaddr)
 		return false;
 
-	/* Disallow mapping page 0.
-	   Not only is it a bad idea to map page 0, but if we allowed
-	   it then user code that passed a null pointer to system calls
-	   could quite likely panic the kernel by way of null pointer
-	   assertions in memcpy(), etc. */
+	/* 0번 페이지 매핑은 허용하지 않는다.
+	   0번 페이지를 매핑하는 것 자체도 좋지 않지만, 이를 허용하면 시스템
+	   호출에 null 포인터를 넘긴 사용자 코드 때문에 memcpy() 등의 null
+	   포인터 검사를 통해 커널이 패닉할 가능성이 크다. */
 	if (phdr->p_vaddr < PGSIZE)
 		return false;
 
-	/* It's okay. */
+	/* 문제가 없다. */
 	return true;
 }
 
 #ifndef VM
-/* Codes of this block will be ONLY USED DURING project 2.
- * If you want to implement the function for whole project 2, implement it
- * outside of #ifndef macro. */
+/* 이 블록의 코드는 project 2에서만 사용된다.
+ * project 2 전체에 대해 함수를 구현하고 싶다면 #ifndef 바깥에 구현하라. */
 
-/* load() helpers. */
+/* load() 보조 함수들. */
 static bool install_page (void *upage, void *kpage, bool writable);
 
-/* Loads a segment starting at offset OFS in FILE at address
- * UPAGE.  In total, READ_BYTES + ZERO_BYTES bytes of virtual
- * memory are initialized, as follows:
+/* FILE의 OFS 오프셋에서 시작하는 세그먼트를 UPAGE 주소에 적재한다.
+ * 총 READ_BYTES + ZERO_BYTES 바이트의 가상 메모리를 다음과 같이
+ * 초기화한다:
  *
- * - READ_BYTES bytes at UPAGE must be read from FILE
- * starting at offset OFS.
+ * - UPAGE의 READ_BYTES 바이트는 FILE의 OFS부터 읽어야 한다.
  *
- * - ZERO_BYTES bytes at UPAGE + READ_BYTES must be zeroed.
+ * - UPAGE + READ_BYTES 이후의 ZERO_BYTES 바이트는 0으로 채워야 한다.
  *
- * The pages initialized by this function must be writable by the
- * user process if WRITABLE is true, read-only otherwise.
+ * WRITABLE이 true이면 여기서 초기화한 페이지는 사용자 프로세스가 쓸 수
+ * 있어야 하고, 아니면 읽기 전용이어야 한다.
  *
- * Return true if successful, false if a memory allocation error
- * or disk read error occurs. */
+ * 성공하면 true를 반환하고, 메모리 할당 오류나 디스크 읽기 오류가 나면
+ * false를 반환한다. */
 static bool
 load_segment (struct file *file, off_t ofs, uint8_t *upage,
 		uint32_t read_bytes, uint32_t zero_bytes, bool writable) {
@@ -567,32 +560,32 @@ load_segment (struct file *file, off_t ofs, uint8_t *upage,
 
 	file_seek (file, ofs);
 	while (read_bytes > 0 || zero_bytes > 0) {
-		/* Do calculate how to fill this page.
-		 * We will read PAGE_READ_BYTES bytes from FILE
-		 * and zero the final PAGE_ZERO_BYTES bytes. */
+		/* 이 페이지를 어떻게 채울지 계산한다.
+		 * FILE에서 PAGE_READ_BYTES 바이트를 읽고
+		 * 마지막 PAGE_ZERO_BYTES 바이트는 0으로 채운다. */
 		size_t page_read_bytes = read_bytes < PGSIZE ? read_bytes : PGSIZE;
 		size_t page_zero_bytes = PGSIZE - page_read_bytes;
 
-		/* Get a page of memory. */
+		/* 메모리 페이지 하나를 가져온다. */
 		uint8_t *kpage = palloc_get_page (PAL_USER);
 		if (kpage == NULL)
 			return false;
 
-		/* Load this page. */
+		/* 이 페이지를 적재한다. */
 		if (file_read (file, kpage, page_read_bytes) != (int) page_read_bytes) {
 			palloc_free_page (kpage);
 			return false;
 		}
 		memset (kpage + page_read_bytes, 0, page_zero_bytes);
 
-		/* Add the page to the process's address space. */
+		/* 이 페이지를 프로세스 주소 공간에 추가한다. */
 		if (!install_page (upage, kpage, writable)) {
 			printf("fail\n");
 			palloc_free_page (kpage);
 			return false;
 		}
 
-		/* Advance. */
+		/* 다음 페이지로 진행한다. */
 		read_bytes -= page_read_bytes;
 		zero_bytes -= page_zero_bytes;
 		upage += PGSIZE;
@@ -600,7 +593,7 @@ load_segment (struct file *file, off_t ofs, uint8_t *upage,
 	return true;
 }
 
-/* Create a minimal stack by mapping a zeroed page at the USER_STACK */
+/* USER_STACK 위치에 0으로 채운 페이지를 매핑해 최소한의 스택을 만든다. */
 static bool
 setup_stack (struct intr_frame *if_) {
 	uint8_t *kpage;
@@ -617,50 +610,47 @@ setup_stack (struct intr_frame *if_) {
 	return success;
 }
 
-/* Adds a mapping from user virtual address UPAGE to kernel
- * virtual address KPAGE to the page table.
- * If WRITABLE is true, the user process may modify the page;
- * otherwise, it is read-only.
- * UPAGE must not already be mapped.
- * KPAGE should probably be a page obtained from the user pool
- * with palloc_get_page().
- * Returns true on success, false if UPAGE is already mapped or
- * if memory allocation fails. */
+/* 사용자 가상 주소 UPAGE를 커널 가상 주소 KPAGE에 연결하는 매핑을
+ * 페이지 테이블에 추가한다.
+ * WRITABLE이 true이면 사용자 프로세스가 이 페이지를 수정할 수 있고,
+ * 아니면 읽기 전용이다.
+ * UPAGE는 아직 매핑되어 있지 않아야 한다.
+ * KPAGE는 보통 palloc_get_page()로 사용자 풀에서 얻은 페이지여야 한다.
+ * 성공하면 true를 반환하고, UPAGE가 이미 매핑되어 있거나 메모리 할당에
+ * 실패하면 false를 반환한다. */
 static bool
 install_page (void *upage, void *kpage, bool writable) {
 	struct thread *t = thread_current ();
 
-	/* Verify that there's not already a page at that virtual
-	 * address, then map our page there. */
+	/* 해당 가상 주소에 페이지가 이미 없는지 확인한 뒤, 거기에 페이지를
+	 * 매핑한다. */
 	return (pml4_get_page (t->pml4, upage) == NULL
 			&& pml4_set_page (t->pml4, upage, kpage, writable));
 }
 #else
-/* From here, codes will be used after project 3.
- * If you want to implement the function for only project 2, implement it on the
- * upper block. */
+/* 여기부터의 코드는 project 3 이후에 사용된다.
+ * project 2만 대상으로 구현하려면 위쪽 블록에 구현하라. */
 
 static bool
 lazy_load_segment (struct page *page, void *aux) {
-	/* TODO: Load the segment from the file */
-	/* TODO: This called when the first page fault occurs on address VA. */
-	/* TODO: VA is available when calling this function. */
+	/* TODO: 파일에서 세그먼트를 적재한다. */
+	/* TODO: 이 함수는 VA 주소에서 첫 페이지 폴트가 발생했을 때 호출된다. */
+	/* TODO: VA는 이 함수가 호출될 때 사용할 수 있다. */
 }
 
-/* Loads a segment starting at offset OFS in FILE at address
- * UPAGE.  In total, READ_BYTES + ZERO_BYTES bytes of virtual
- * memory are initialized, as follows:
+/* FILE의 OFS 오프셋에서 시작하는 세그먼트를 UPAGE 주소에 적재한다.
+ * 총 READ_BYTES + ZERO_BYTES 바이트의 가상 메모리를 다음과 같이
+ * 초기화한다:
  *
- * - READ_BYTES bytes at UPAGE must be read from FILE
- * starting at offset OFS.
+ * - UPAGE의 READ_BYTES 바이트는 FILE의 OFS부터 읽어야 한다.
  *
- * - ZERO_BYTES bytes at UPAGE + READ_BYTES must be zeroed.
+ * - UPAGE + READ_BYTES 이후의 ZERO_BYTES 바이트는 0으로 채워야 한다.
  *
- * The pages initialized by this function must be writable by the
- * user process if WRITABLE is true, read-only otherwise.
+ * WRITABLE이 true이면 여기서 초기화한 페이지는 사용자 프로세스가 쓸 수
+ * 있어야 하고, 아니면 읽기 전용이어야 한다.
  *
- * Return true if successful, false if a memory allocation error
- * or disk read error occurs. */
+ * 성공하면 true를 반환하고, 메모리 할당 오류나 디스크 읽기 오류가 나면
+ * false를 반환한다. */
 static bool
 load_segment (struct file *file, off_t ofs, uint8_t *upage,
 		uint32_t read_bytes, uint32_t zero_bytes, bool writable) {
@@ -669,19 +659,19 @@ load_segment (struct file *file, off_t ofs, uint8_t *upage,
 	ASSERT (ofs % PGSIZE == 0);
 
 	while (read_bytes > 0 || zero_bytes > 0) {
-		/* Do calculate how to fill this page.
-		 * We will read PAGE_READ_BYTES bytes from FILE
-		 * and zero the final PAGE_ZERO_BYTES bytes. */
+		/* 이 페이지를 어떻게 채울지 계산한다.
+		 * FILE에서 PAGE_READ_BYTES 바이트를 읽고
+		 * 마지막 PAGE_ZERO_BYTES 바이트는 0으로 채운다. */
 		size_t page_read_bytes = read_bytes < PGSIZE ? read_bytes : PGSIZE;
 		size_t page_zero_bytes = PGSIZE - page_read_bytes;
 
-		/* TODO: Set up aux to pass information to the lazy_load_segment. */
+		/* TODO: lazy_load_segment에 전달할 정보를 담은 aux를 준비한다. */
 		void *aux = NULL;
 		if (!vm_alloc_page_with_initializer (VM_ANON, upage,
 					writable, lazy_load_segment, aux))
 			return false;
 
-		/* Advance. */
+		/* 다음 페이지로 진행한다. */
 		read_bytes -= page_read_bytes;
 		zero_bytes -= page_zero_bytes;
 		upage += PGSIZE;
@@ -689,16 +679,16 @@ load_segment (struct file *file, off_t ofs, uint8_t *upage,
 	return true;
 }
 
-/* Create a PAGE of stack at the USER_STACK. Return true on success. */
+/* USER_STACK에 스택 페이지를 만든다. 성공하면 true를 반환한다. */
 static bool
 setup_stack (struct intr_frame *if_) {
 	bool success = false;
 	void *stack_bottom = (void *) (((uint8_t *) USER_STACK) - PGSIZE);
 
-	/* TODO: Map the stack on stack_bottom and claim the page immediately.
-	 * TODO: If success, set the rsp accordingly.
-	 * TODO: You should mark the page is stack. */
-	/* TODO: Your code goes here */
+	/* TODO: stack_bottom에 스택을 매핑하고 페이지를 즉시 점유한다.
+	 * TODO: 성공하면 rsp를 그에 맞게 설정한다.
+	 * TODO: 해당 페이지를 스택 페이지로 표시해야 한다. */
+	/* TODO: 여기에 코드를 작성한다. */
 
 	return success;
 }

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -17,7 +17,6 @@
 #include "threads/thread.h"
 #include "threads/mmu.h"
 #include "threads/vaddr.h"
-#include "threads/synch.h"
 #include "intrinsic.h"
 #ifdef VM
 #include "vm/vm.h"
@@ -27,73 +26,35 @@ static void process_cleanup (void);
 static bool load (const char *file_name, struct intr_frame *if_);
 static void initd (void *f_name);
 static void __do_fork (void *);
-static bool parse_filename(const char *file_name, char *tmp, size_t tmp_size);
 
-static struct semaphore wait_sema;
-static bool waited;
-static int exit_status;
-
-/* initd와 그 외 프로세스에서 공통으로 사용하는 초기화 함수. */
+/* General process initializer for initd and other process. */
 static void
 process_init (void) {
 	struct thread *current = thread_current ();
 }
 
-/* FILE_NAME에서 읽어들인 첫 번째 사용자 영역 프로그램 "initd"를 시작한다.
- * process_create_initd()가 반환되기 전에 새 스레드가 스케줄될 수도 있고,
- * 심지어 종료될 수도 있다. 성공하면 initd의 스레드 ID를 반환하고,
- * 스레드를 만들 수 없으면 TID_ERROR를 반환한다.
- * 이 함수는 반드시 한 번만 호출해야 한다. */
+/* Starts the first userland program, called "initd", loaded from FILE_NAME.
+ * The new thread may be scheduled (and may even exit)
+ * before process_create_initd() returns. Returns the initd's
+ * thread id, or TID_ERROR if the thread cannot be created.
+ * Notice that THIS SHOULD BE CALLED ONCE. */
 tid_t
 process_create_initd (const char *file_name) {
 	char *fn_copy;
 	tid_t tid;
 
-	/* FILE_NAME의 사본을 만든다.
-	 * 그렇지 않으면 호출자와 load() 사이에 경쟁 상태가 생긴다. */
+	/* Make a copy of FILE_NAME.
+	 * Otherwise there's a race between the caller and load(). */
 	fn_copy = palloc_get_page (0);
 	if (fn_copy == NULL)
 		return TID_ERROR;
 	strlcpy (fn_copy, file_name, PGSIZE);
 
-	char *tmp = palloc_get_page(0);
-	if (tmp == NULL) {
-		palloc_free_page(fn_copy);
-		return TID_ERROR;
-	}
-
-	if (!parse_filename(file_name, tmp, PGSIZE)) {
-		palloc_free_page(tmp);
-		palloc_free_page(fn_copy);
-		return TID_ERROR;
-	}
-
-	if (!waited) {
-		sema_init(&wait_sema, 0);
-		waited = true;
-	}
-
 	/* Create a new thread to execute FILE_NAME. */
-	tid = thread_create (tmp, PRI_DEFAULT, initd, fn_copy);
+	tid = thread_create (file_name, PRI_DEFAULT, initd, fn_copy);
 	if (tid == TID_ERROR)
 		palloc_free_page (fn_copy);
-	
-	palloc_free_page(tmp);
-
 	return tid;
-}
-
-static bool parse_filename(const char *file_name, char *tmp, size_t tmp_size) {
-	if (tmp == NULL || file_name == NULL) {
-		return false;
-	}
-
-	strlcpy(tmp, file_name, tmp_size);
-
-	char *save_token;
-	char *token = strtok_r(tmp, " ", &save_token);
-	
-	return token != NULL;
 }
 
 /* A thread function that launches first user process. */
@@ -110,18 +71,18 @@ initd (void *f_name) {
 	NOT_REACHED ();
 }
 
-/* 현재 프로세스를 `name`이라는 이름으로 복제한다. 성공하면 새 프로세스의
- * 스레드 ID를 반환하고, 스레드를 만들 수 없으면 TID_ERROR를 반환한다. */
+/* Clones the current process as `name`. Returns the new process's thread id, or
+ * TID_ERROR if the thread cannot be created. */
 tid_t
 process_fork (const char *name, struct intr_frame *if_ UNUSED) {
-	/* 현재 스레드를 새 스레드로 복제한다. */
+	/* Clone current thread to new thread.*/
 	return thread_create (name,
 			PRI_DEFAULT, __do_fork, thread_current ());
 }
 
 #ifndef VM
-/* 이 함수를 pml4_for_each에 넘겨 부모의 주소 공간을 복제한다.
- * project 2에서만 사용한다. */
+/* Duplicate the parent's address space by passing this function to the
+ * pml4_for_each. This is only for the project 2. */
 static bool
 duplicate_pte (uint64_t *pte, void *va, void *aux) {
 	struct thread *current = thread_current ();
@@ -130,43 +91,44 @@ duplicate_pte (uint64_t *pte, void *va, void *aux) {
 	void *newpage;
 	bool writable;
 
-	/* 1. TODO: parent_page가 커널 페이지라면 즉시 반환한다. */
+	/* 1. TODO: If the parent_page is kernel page, then return immediately. */
 
-	/* 2. 부모의 페이지 맵 레벨 4에서 VA를 찾는다. */
+	/* 2. Resolve VA from the parent's page map level 4. */
 	parent_page = pml4_get_page (parent->pml4, va);
 
-	/* 3. TODO: 자식용 새 PAL_USER 페이지를 할당하고 결과를
-	 *    TODO: NEWPAGE에 저장한다. */
+	/* 3. TODO: Allocate new PAL_USER page for the child and set result to
+	 *    TODO: NEWPAGE. */
 
-	/* 4. TODO: 부모 페이지 내용을 새 페이지로 복사하고,
-	 *    TODO: 부모 페이지의 쓰기 가능 여부를 확인해 그 결과에 따라
-	 *    TODO: WRITABLE을 설정한다. */
+	/* 4. TODO: Duplicate parent's page to the new page and
+	 *    TODO: check whether parent's page is writable or not (set WRITABLE
+	 *    TODO: according to the result). */
 
-	/* 5. VA 주소에 WRITABLE 권한으로 새 페이지를 자식의 페이지 테이블에
-	 *    추가한다. */
+	/* 5. Add new page to child's page table at address VA with WRITABLE
+	 *    permission. */
 	if (!pml4_set_page (current->pml4, va, newpage, writable)) {
-		/* 6. TODO: 페이지 삽입에 실패하면 오류 처리를 한다. */
+		/* 6. TODO: if fail to insert page, do error handling. */
 	}
 	return true;
 }
 #endif
 
-/* 부모의 실행 문맥을 복사하는 스레드 함수.
- * 힌트) parent->tf에는 프로세스의 사용자 영역 문맥이 들어 있지 않다.
- *       즉, process_fork의 두 번째 인자를 이 함수로 전달해야 한다. */
+/* A thread function that copies parent's execution context.
+ * Hint) parent->tf does not hold the userland context of the process.
+ *       That is, you are required to pass second argument of process_fork to
+ *       this function. */
 static void
 __do_fork (void *aux) {
 	struct intr_frame if_;
 	struct thread *parent = (struct thread *) aux;
 	struct thread *current = thread_current ();
-	/* TODO: parent_if를 적절히 전달한다. (즉, process_fork()의 if_) */
+	/* TODO: somehow pass the parent_if. (i.e. process_fork()'s if_) */
 	struct intr_frame *parent_if;
 	bool succ = true;
 
-	/* 1. CPU 문맥을 로컬 스택으로 읽어온다. */
+	/* 1. Read the cpu context to local stack. */
 	memcpy (&if_, parent_if, sizeof (struct intr_frame));
 
-	/* 2. 페이지 테이블을 복제한다. */
+	/* 2. Duplicate PT */
 	current->pml4 = pml4_create();
 	if (current->pml4 == NULL)
 		goto error;
@@ -181,30 +143,20 @@ __do_fork (void *aux) {
 		goto error;
 #endif
 
-	/* TODO: 여기에 코드를 작성한다.
-	 * TODO: 힌트) 파일 객체를 복제하려면 include/filesys/file.h의
-	 * TODO:       `file_duplicate`를 사용한다. 이 함수가 부모의 자원을
-	 * TODO:       성공적으로 복제하기 전까지 부모는 fork()에서 반환하면
-	 * TODO:       안 된다. */
+	/* TODO: Your code goes here.
+	 * TODO: Hint) To duplicate the file object, use `file_duplicate`
+	 * TODO:       in include/filesys/file.h. Note that parent should not return
+	 * TODO:       from the fork() until this function successfully duplicates
+	 * TODO:       the resources of parent.*/
 
 	process_init ();
 
-	/* 마지막으로 새로 만들어진 프로세스로 전환한다. */
+	/* Finally, switch to the newly created process. */
 	if (succ)
 		do_iret (&if_);
 error:
 	thread_exit ();
 }
-
-// 자식 스레드 상태
-struct child_status {
-	tid_t tid;                     /* 자식 스레드 tid */
-	int exit_status;               /* 자식이 exit()할 때 남긴 종료 코드 */
-	bool exited;                   /* 자식이 종료했는지 여부 */
-	bool waited;                   /* 부모가 자식에 대해서 wait() 했는지 여부 */
-	struct semaphore wait_sema;    /* 부모가 자식 종료를 기다릴 때 사용하는 세마포어 */
-	struct list_elem elem;         /* child list 리스트 노드 */
-};
 
 /* Switch the current execution context to the f_name.
  * Returns -1 on fail. */
@@ -213,79 +165,61 @@ process_exec (void *f_name) {
 	char *file_name = f_name;
 	bool success;
 
-	/* thread 구조체 안의 intr_frame은 사용할 수 없다.
-	 * 현재 스레드가 다시 스케줄될 때 해당 멤버에 실행 정보가 저장되기
-	 * 때문이다. */
-	struct intr_frame _if;
+	/* We cannot use the intr_frame in the thread structure.
+	 * This is because when current thread rescheduled,
+	 * it stores the execution information to the member. */
+	struct intr_frame _if; 
 	_if.ds = _if.es = _if.ss = SEL_UDSEG;
 	_if.cs = SEL_UCSEG;
 	_if.eflags = FLAG_IF | FLAG_MBS;
 
-	/* 먼저 현재 문맥을 정리한다. */
+	/* We first kill the current context */
 	process_cleanup ();
 
-	/* 그다음 바이너리를 적재한다. */
+	/* And then load the binary */
 	success = load (file_name, &_if);
 
-	/* 적재에 실패하면 종료한다. */
+	/* If load failed, quit. */
 	palloc_free_page (file_name);
 	if (!success)
 		return -1;
 
-	/* 전환된 프로세스를 시작한다. */
+	/* Start switched process. */
 	do_iret (&_if);
 	NOT_REACHED ();
 }
 
 
-/* 스레드 TID가 종료될 때까지 기다렸다가 종료 상태를 반환한다. 커널에 의해
- * 종료된 경우(즉, 예외 때문에 죽은 경우)에는 -1을 반환한다. TID가
- * 잘못되었거나, 호출한 프로세스의 자식이 아니거나, 해당 TID에 대해
- * process_wait()가 이미 성공적으로 호출된 적이 있다면 기다리지 않고 즉시
- * -1을 반환한다.
+/* Waits for thread TID to die and returns its exit status.  If
+ * it was terminated by the kernel (i.e. killed due to an
+ * exception), returns -1.  If TID is invalid or if it was not a
+ * child of the calling process, or if process_wait() has already
+ * been successfully called for the given TID, returns -1
+ * immediately, without waiting.
  *
- * 이 함수는 problem 2-2에서 구현한다. 현재는 아무 일도 하지 않는다. */
+ * This function will be implemented in problem 2-2.  For now, it
+ * does nothing. */
 int
 process_wait (tid_t child_tid UNUSED) {
 	/* XXX: Hint) The pintos exit if process_wait (initd), we recommend you
 	 * XXX:       to add infinite loop here before
 	 * XXX:       implementing the process_wait. */
-	sema_down(&wait_sema);
-	return exit_status;
+	return -1;
 }
 
-/* 프로세스를 종료한다. 이 함수는 thread_exit()에서 호출된다. */
+/* Exit the process. This function is called by thread_exit (). */
 void
 process_exit (void) {
 	struct thread *curr = thread_current ();
-	/* TODO: 여기에 코드를 작성한다.
-	 * TODO: 프로세스 종료 메시지를 구현한다
-	 * TODO: (project2/process_termination.html 참고).
-	 * TODO: 프로세스 자원 정리도 여기서 구현하는 것을 권장한다. */
-
-	/*
-	 * 종료 메시지 출력
-	 * 부모가 wait()로 회수할 수 있도록 종료 상태 반영
-	 * 부모가 기다리고 있으면 깨우기
-	 * 열린 자원 정리
-	 * 주소 공간 정리
-	*/
-	printf ("%s: exit(%d)\n", thread_name(), (int) curr->exit_status);
-	exit_status = curr->exit_status;
-	sema_up(&wait_sema);
-	
-	// struct child_status *child = curr->my_status;
-	// child->exit_status = curr->exit_status;
-	// child->exited = true;
-
-	// if (child->waited) {
-	// 	sema_up(&child->wait_sema);
-	// }
+	/* TODO: Your code goes here.
+	 * TODO: Implement process termination message (see
+	 * TODO: project2/process_termination.html).
+	 * TODO: We recommend you to implement process resource cleanup here. */
 
 	process_cleanup ();
 }
 
-/* 현재 프로세스의 자원을 해제한다. */
+/* Free the current process's resources. */
 static void
 process_cleanup (void) {
 	struct thread *curr = thread_current ();
@@ -295,54 +229,55 @@ process_cleanup (void) {
 #endif
 
 	uint64_t *pml4;
-	/* 현재 프로세스의 페이지 디렉터리를 파괴하고 커널 전용 페이지
-	 * 디렉터리로 돌아간다. */
+	/* Destroy the current process's page directory and switch back
+	 * to the kernel-only page directory. */
 	pml4 = curr->pml4;
 	if (pml4 != NULL) {
-		/* 여기서는 순서가 매우 중요하다. 타이머 인터럽트가 다시
-		 * 프로세스 페이지 디렉터리로 전환하지 못하게, 페이지 디렉터리를
-		 * 바꾸기 전에 cur->pagedir을 NULL로 설정해야 한다. 또한
-		 * 프로세스 페이지 디렉터리를 파괴하기 전에 기본 페이지
-		 * 디렉터리를 활성화해야 한다. 그렇지 않으면 현재 활성 페이지
-		 * 디렉터리가 이미 해제된(그리고 비워진) 것이 된다. */
+		/* Correct ordering here is crucial.  We must set
+		 * cur->pagedir to NULL before switching page directories,
+		 * so that a timer interrupt can't switch back to the
+		 * process page directory.  We must activate the base page
+		 * directory before destroying the process's page
+		 * directory, or our active page directory will be one
+		 * that's been freed (and cleared). */
 		curr->pml4 = NULL;
 		pml4_activate (NULL);
 		pml4_destroy (pml4);
 	}
 }
 
-/* 다음 스레드에서 사용자 코드를 실행할 수 있도록 CPU를 설정한다.
- * 이 함수는 문맥 전환이 일어날 때마다 호출된다. */
+/* Sets up the CPU for running user code in the nest thread.
+ * This function is called on every context switch. */
 void
 process_activate (struct thread *next) {
-	/* 스레드의 페이지 테이블을 활성화한다. */
+	/* Activate thread's page tables. */
 	pml4_activate (next->pml4);
 
-	/* 인터럽트 처리에 사용할 스레드의 커널 스택을 설정한다. */
+	/* Set thread's kernel stack for use in processing interrupts. */
 	tss_update (next);
 }
 
-/* ELF 바이너리를 적재한다. 아래 정의는 [ELF1]의 ELF 명세를 거의 그대로
- * 가져온 것이다. */
+/* We load ELF binaries.  The following definitions are taken
+ * from the ELF specification, [ELF1], more-or-less verbatim.  */
 
-/* ELF 타입. [ELF1] 1-2 참고. */
+/* ELF types.  See [ELF1] 1-2. */
 #define EI_NIDENT 16
 
-#define PT_NULL    0            /* 무시. */
-#define PT_LOAD    1            /* 적재 가능한 세그먼트. */
-#define PT_DYNAMIC 2            /* 동적 링크 정보. */
-#define PT_INTERP  3            /* 동적 로더 이름. */
-#define PT_NOTE    4            /* 보조 정보. */
-#define PT_SHLIB   5            /* 예약됨. */
-#define PT_PHDR    6            /* 프로그램 헤더 테이블. */
-#define PT_STACK   0x6474e551   /* 스택 세그먼트. */
+#define PT_NULL    0            /* Ignore. */
+#define PT_LOAD    1            /* Loadable segment. */
+#define PT_DYNAMIC 2            /* Dynamic linking info. */
+#define PT_INTERP  3            /* Name of dynamic loader. */
+#define PT_NOTE    4            /* Auxiliary info. */
+#define PT_SHLIB   5            /* Reserved. */
+#define PT_PHDR    6            /* Program header table. */
+#define PT_STACK   0x6474e551   /* Stack segment. */
 
-#define PF_X 1          /* 실행 가능. */
-#define PF_W 2          /* 쓰기 가능. */
-#define PF_R 4          /* 읽기 가능. */
+#define PF_X 1          /* Executable. */
+#define PF_W 2          /* Writable. */
+#define PF_R 4          /* Readable. */
 
-/* 실행 파일 헤더. [ELF1] 1-4~1-8 참고.
- * ELF 바이너리의 맨 앞부분에 위치한다. */
+/* Executable header.  See [ELF1] 1-4 to 1-8.
+ * This appears at the very beginning of an ELF binary. */
 struct ELF64_hdr {
 	unsigned char e_ident[EI_NIDENT];
 	uint16_t e_type;
@@ -371,7 +306,7 @@ struct ELF64_PHDR {
 	uint64_t p_align;
 };
 
-/* 약어 */
+/* Abbreviations */
 #define ELF ELF64_hdr
 #define Phdr ELF64_PHDR
 
@@ -380,8 +315,6 @@ static bool validate_segment (const struct Phdr *, struct file *);
 static bool load_segment (struct file *file, off_t ofs, uint8_t *upage,
 		uint32_t read_bytes, uint32_t zero_bytes,
 		bool writable);
-
-#define MAX_ARGC 63
 
 /* Loads an ELF executable from FILE_NAME into the current thread.
  * Stores the executable's entry point into *RIP
@@ -402,24 +335,21 @@ load (const char *file_name, struct intr_frame *if_) {
 	}
 	strlcpy(file_name_copy, file_name, PGSIZE);
 	/* NULL까지 반복하여 argv 만들기 */
-	char *argv[MAX_ARGC + 1];
+	char *argv[64];
 	char *save_ptr;
 	char *token = strtok_r(file_name_copy, " ", &save_ptr);
 	if (token == NULL) {
 		goto done;
 	}
 	int argc = 0;
-	while (token != NULL) {
-		if (argc >= MAX_ARGC) {
-			goto done;
-		}
+	while (token != NULL && argc < 63 ) {
 		argv[argc] = token;
 		argc++;
 		token = strtok_r(NULL, " ", &save_ptr);
 	}
 	argv[argc] = NULL; // 배열의 마지막 값은 NULL로 설정
 
-	/* 페이지 디렉터리를 할당하고 활성화한다. */
+	/* Allocate and activate page directory. */
 	t->pml4 = pml4_create ();
 	if (t->pml4 == NULL)
 		goto done;
@@ -428,15 +358,15 @@ load (const char *file_name, struct intr_frame *if_) {
 	/* Open executable file. */
 	file = filesys_open (argv[0]);
 	if (file == NULL) {
-		printf ("load: %s: open failed\n", argv[0]);
+		printf ("load: %s: open failed\n", file_name);
 		goto done;
 	}
 
-	/* 실행 파일 헤더를 읽고 검증한다. */
+	/* Read and verify executable header. */
 	if (file_read (file, &ehdr, sizeof ehdr) != sizeof ehdr
 			|| memcmp (ehdr.e_ident, "\177ELF\2\1\1", 7)
 			|| ehdr.e_type != 2
-			|| ehdr.e_machine != 0x3E // amd64 아키텍처
+			|| ehdr.e_machine != 0x3E // amd64
 			|| ehdr.e_version != 1
 			|| ehdr.e_phentsize != sizeof (struct Phdr)
 			|| ehdr.e_phnum > 1024) {
@@ -444,7 +374,7 @@ load (const char *file_name, struct intr_frame *if_) {
 		goto done;
 	}
 
-	/* 프로그램 헤더를 읽는다. */
+	/* Read program headers. */
 	file_ofs = ehdr.e_phoff;
 	for (i = 0; i < ehdr.e_phnum; i++) {
 		struct Phdr phdr;
@@ -462,7 +392,7 @@ load (const char *file_name, struct intr_frame *if_) {
 			case PT_PHDR:
 			case PT_STACK:
 			default:
-				/* 이 세그먼트는 무시한다. */
+				/* Ignore this segment. */
 				break;
 			case PT_DYNAMIC:
 			case PT_INTERP:
@@ -476,14 +406,14 @@ load (const char *file_name, struct intr_frame *if_) {
 					uint64_t page_offset = phdr.p_vaddr & PGMASK;
 					uint32_t read_bytes, zero_bytes;
 					if (phdr.p_filesz > 0) {
-						/* 일반 세그먼트.
-						 * 앞부분은 디스크에서 읽고 나머지는 0으로 채운다. */
+						/* Normal segment.
+						 * Read initial part from disk and zero the rest. */
 						read_bytes = page_offset + phdr.p_filesz;
 						zero_bytes = (ROUND_UP (page_offset + phdr.p_memsz, PGSIZE)
 								- read_bytes);
 					} else {
-						/* 전부 0으로 채워진 세그먼트.
-						 * 디스크에서는 아무것도 읽지 않는다. */
+						/* Entirely zero.
+						 * Don't read anything from disk. */
 						read_bytes = 0;
 						zero_bytes = ROUND_UP (page_offset + phdr.p_memsz, PGSIZE);
 					}
@@ -497,18 +427,18 @@ load (const char *file_name, struct intr_frame *if_) {
 		}
 	}
 
-	/* 스택을 설정한다. */
+	/* Set up stack. */
 	if (!setup_stack (if_))
 		goto done;
 
-	/* 시작 주소를 설정한다. */
+	/* Start address. */
 	if_->rip = ehdr.e_entry;
 
 	/* TODO: Your code goes here.
 	/* TODO: Implement argument passing (see project2/argument_passing.html). */
 	/* 스택에 토큰 올리기 */
 	// 스택 맨 위에 명령줄 문자열 삽입한다
-	char *arg_addr[MAX_ARGC];
+	char *arg_addr[64];
 	int j = 0;
 
 	while (argv[j] != NULL) {
@@ -562,69 +492,72 @@ done:
 }
 
 
-/* PHDR이 FILE 안의 유효하고 적재 가능한 세그먼트를 설명하는지 검사한다.
- * 맞으면 true, 아니면 false를 반환한다. */
+/* Checks whether PHDR describes a valid, loadable segment in
+ * FILE and returns true if so, false otherwise. */
 static bool
 validate_segment (const struct Phdr *phdr, struct file *file) {
-	/* p_offset과 p_vaddr은 같은 페이지 오프셋을 가져야 한다. */
+	/* p_offset and p_vaddr must have the same page offset. */
 	if ((phdr->p_offset & PGMASK) != (phdr->p_vaddr & PGMASK))
 		return false;
 
-	/* p_offset은 FILE 내부를 가리켜야 한다. */
+	/* p_offset must point within FILE. */
 	if (phdr->p_offset > (uint64_t) file_length (file))
 		return false;
 
-	/* p_memsz는 최소한 p_filesz 이상이어야 한다. */
+	/* p_memsz must be at least as big as p_filesz. */
 	if (phdr->p_memsz < phdr->p_filesz)
 		return false;
 
-	/* 세그먼트는 비어 있으면 안 된다. */
+	/* The segment must not be empty. */
 	if (phdr->p_memsz == 0)
 		return false;
 
-	/* 가상 메모리 영역의 시작과 끝은 모두 사용자 주소 공간 범위 안에
-	   있어야 한다. */
+	/* The virtual memory region must both start and end within the
+	   user address space range. */
 	if (!is_user_vaddr ((void *) phdr->p_vaddr))
 		return false;
 	if (!is_user_vaddr ((void *) (phdr->p_vaddr + phdr->p_memsz)))
 		return false;
 
-	/* 이 영역이 커널 가상 주소 공간을 가로질러 "되감기"처럼
-	   넘쳐서는 안 된다. */
+	/* The region cannot "wrap around" across the kernel virtual
+	   address space. */
 	if (phdr->p_vaddr + phdr->p_memsz < phdr->p_vaddr)
 		return false;
 
-	/* 0번 페이지 매핑은 허용하지 않는다.
-	   0번 페이지를 매핑하는 것 자체도 좋지 않지만, 이를 허용하면 시스템
-	   호출에 null 포인터를 넘긴 사용자 코드 때문에 memcpy() 등의 null
-	   포인터 검사를 통해 커널이 패닉할 가능성이 크다. */
+	/* Disallow mapping page 0.
+	   Not only is it a bad idea to map page 0, but if we allowed
+	   it then user code that passed a null pointer to system calls
+	   could quite likely panic the kernel by way of null pointer
+	   assertions in memcpy(), etc. */
 	if (phdr->p_vaddr < PGSIZE)
 		return false;
 
-	/* 문제가 없다. */
+	/* It's okay. */
 	return true;
 }
 
 #ifndef VM
-/* 이 블록의 코드는 project 2에서만 사용된다.
- * project 2 전체에 대해 함수를 구현하고 싶다면 #ifndef 바깥에 구현하라. */
+/* Codes of this block will be ONLY USED DURING project 2.
+ * If you want to implement the function for whole project 2, implement it
+ * outside of #ifndef macro. */
 
-/* load() 보조 함수들. */
+/* load() helpers. */
 static bool install_page (void *upage, void *kpage, bool writable);
 
-/* FILE의 OFS 오프셋에서 시작하는 세그먼트를 UPAGE 주소에 적재한다.
- * 총 READ_BYTES + ZERO_BYTES 바이트의 가상 메모리를 다음과 같이
- * 초기화한다:
+/* Loads a segment starting at offset OFS in FILE at address
+ * UPAGE.  In total, READ_BYTES + ZERO_BYTES bytes of virtual
+ * memory are initialized, as follows:
  *
- * - UPAGE의 READ_BYTES 바이트는 FILE의 OFS부터 읽어야 한다.
+ * - READ_BYTES bytes at UPAGE must be read from FILE
+ * starting at offset OFS.
  *
- * - UPAGE + READ_BYTES 이후의 ZERO_BYTES 바이트는 0으로 채워야 한다.
+ * - ZERO_BYTES bytes at UPAGE + READ_BYTES must be zeroed.
  *
- * WRITABLE이 true이면 여기서 초기화한 페이지는 사용자 프로세스가 쓸 수
- * 있어야 하고, 아니면 읽기 전용이어야 한다.
+ * The pages initialized by this function must be writable by the
+ * user process if WRITABLE is true, read-only otherwise.
  *
- * 성공하면 true를 반환하고, 메모리 할당 오류나 디스크 읽기 오류가 나면
- * false를 반환한다. */
+ * Return true if successful, false if a memory allocation error
+ * or disk read error occurs. */
 static bool
 load_segment (struct file *file, off_t ofs, uint8_t *upage,
 		uint32_t read_bytes, uint32_t zero_bytes, bool writable) {
@@ -634,32 +567,32 @@ load_segment (struct file *file, off_t ofs, uint8_t *upage,
 
 	file_seek (file, ofs);
 	while (read_bytes > 0 || zero_bytes > 0) {
-		/* 이 페이지를 어떻게 채울지 계산한다.
-		 * FILE에서 PAGE_READ_BYTES 바이트를 읽고
-		 * 마지막 PAGE_ZERO_BYTES 바이트는 0으로 채운다. */
+		/* Do calculate how to fill this page.
+		 * We will read PAGE_READ_BYTES bytes from FILE
+		 * and zero the final PAGE_ZERO_BYTES bytes. */
 		size_t page_read_bytes = read_bytes < PGSIZE ? read_bytes : PGSIZE;
 		size_t page_zero_bytes = PGSIZE - page_read_bytes;
 
-		/* 메모리 페이지 하나를 가져온다. */
+		/* Get a page of memory. */
 		uint8_t *kpage = palloc_get_page (PAL_USER);
 		if (kpage == NULL)
 			return false;
 
-		/* 이 페이지를 적재한다. */
+		/* Load this page. */
 		if (file_read (file, kpage, page_read_bytes) != (int) page_read_bytes) {
 			palloc_free_page (kpage);
 			return false;
 		}
 		memset (kpage + page_read_bytes, 0, page_zero_bytes);
 
-		/* 이 페이지를 프로세스 주소 공간에 추가한다. */
+		/* Add the page to the process's address space. */
 		if (!install_page (upage, kpage, writable)) {
 			printf("fail\n");
 			palloc_free_page (kpage);
 			return false;
 		}
 
-		/* 다음 페이지로 진행한다. */
+		/* Advance. */
 		read_bytes -= page_read_bytes;
 		zero_bytes -= page_zero_bytes;
 		upage += PGSIZE;
@@ -667,7 +600,7 @@ load_segment (struct file *file, off_t ofs, uint8_t *upage,
 	return true;
 }
 
-/* USER_STACK 위치에 0으로 채운 페이지를 매핑해 최소한의 스택을 만든다. */
+/* Create a minimal stack by mapping a zeroed page at the USER_STACK */
 static bool
 setup_stack (struct intr_frame *if_) {
 	uint8_t *kpage;
@@ -684,47 +617,50 @@ setup_stack (struct intr_frame *if_) {
 	return success;
 }
 
-/* 사용자 가상 주소 UPAGE를 커널 가상 주소 KPAGE에 연결하는 매핑을
- * 페이지 테이블에 추가한다.
- * WRITABLE이 true이면 사용자 프로세스가 이 페이지를 수정할 수 있고,
- * 아니면 읽기 전용이다.
- * UPAGE는 아직 매핑되어 있지 않아야 한다.
- * KPAGE는 보통 palloc_get_page()로 사용자 풀에서 얻은 페이지여야 한다.
- * 성공하면 true를 반환하고, UPAGE가 이미 매핑되어 있거나 메모리 할당에
- * 실패하면 false를 반환한다. */
+/* Adds a mapping from user virtual address UPAGE to kernel
+ * virtual address KPAGE to the page table.
+ * If WRITABLE is true, the user process may modify the page;
+ * otherwise, it is read-only.
+ * UPAGE must not already be mapped.
+ * KPAGE should probably be a page obtained from the user pool
+ * with palloc_get_page().
+ * Returns true on success, false if UPAGE is already mapped or
+ * if memory allocation fails. */
 static bool
 install_page (void *upage, void *kpage, bool writable) {
 	struct thread *t = thread_current ();
 
-	/* 해당 가상 주소에 페이지가 이미 없는지 확인한 뒤, 거기에 페이지를
-	 * 매핑한다. */
+	/* Verify that there's not already a page at that virtual
+	 * address, then map our page there. */
 	return (pml4_get_page (t->pml4, upage) == NULL
 			&& pml4_set_page (t->pml4, upage, kpage, writable));
 }
 #else
-/* 여기부터의 코드는 project 3 이후에 사용된다.
- * project 2만 대상으로 구현하려면 위쪽 블록에 구현하라. */
+/* From here, codes will be used after project 3.
+ * If you want to implement the function for only project 2, implement it on the
+ * upper block. */
 
 static bool
 lazy_load_segment (struct page *page, void *aux) {
-	/* TODO: 파일에서 세그먼트를 적재한다. */
-	/* TODO: 이 함수는 VA 주소에서 첫 페이지 폴트가 발생했을 때 호출된다. */
-	/* TODO: VA는 이 함수가 호출될 때 사용할 수 있다. */
+	/* TODO: Load the segment from the file */
+	/* TODO: This called when the first page fault occurs on address VA. */
+	/* TODO: VA is available when calling this function. */
 }
 
-/* FILE의 OFS 오프셋에서 시작하는 세그먼트를 UPAGE 주소에 적재한다.
- * 총 READ_BYTES + ZERO_BYTES 바이트의 가상 메모리를 다음과 같이
- * 초기화한다:
+/* Loads a segment starting at offset OFS in FILE at address
+ * UPAGE.  In total, READ_BYTES + ZERO_BYTES bytes of virtual
+ * memory are initialized, as follows:
  *
- * - UPAGE의 READ_BYTES 바이트는 FILE의 OFS부터 읽어야 한다.
+ * - READ_BYTES bytes at UPAGE must be read from FILE
+ * starting at offset OFS.
  *
- * - UPAGE + READ_BYTES 이후의 ZERO_BYTES 바이트는 0으로 채워야 한다.
+ * - ZERO_BYTES bytes at UPAGE + READ_BYTES must be zeroed.
  *
- * WRITABLE이 true이면 여기서 초기화한 페이지는 사용자 프로세스가 쓸 수
- * 있어야 하고, 아니면 읽기 전용이어야 한다.
+ * The pages initialized by this function must be writable by the
+ * user process if WRITABLE is true, read-only otherwise.
  *
- * 성공하면 true를 반환하고, 메모리 할당 오류나 디스크 읽기 오류가 나면
- * false를 반환한다. */
+ * Return true if successful, false if a memory allocation error
+ * or disk read error occurs. */
 static bool
 load_segment (struct file *file, off_t ofs, uint8_t *upage,
 		uint32_t read_bytes, uint32_t zero_bytes, bool writable) {
@@ -733,19 +669,19 @@ load_segment (struct file *file, off_t ofs, uint8_t *upage,
 	ASSERT (ofs % PGSIZE == 0);
 
 	while (read_bytes > 0 || zero_bytes > 0) {
-		/* 이 페이지를 어떻게 채울지 계산한다.
-		 * FILE에서 PAGE_READ_BYTES 바이트를 읽고
-		 * 마지막 PAGE_ZERO_BYTES 바이트는 0으로 채운다. */
+		/* Do calculate how to fill this page.
+		 * We will read PAGE_READ_BYTES bytes from FILE
+		 * and zero the final PAGE_ZERO_BYTES bytes. */
 		size_t page_read_bytes = read_bytes < PGSIZE ? read_bytes : PGSIZE;
 		size_t page_zero_bytes = PGSIZE - page_read_bytes;
 
-		/* TODO: lazy_load_segment에 전달할 정보를 담은 aux를 준비한다. */
+		/* TODO: Set up aux to pass information to the lazy_load_segment. */
 		void *aux = NULL;
 		if (!vm_alloc_page_with_initializer (VM_ANON, upage,
 					writable, lazy_load_segment, aux))
 			return false;
 
-		/* 다음 페이지로 진행한다. */
+		/* Advance. */
 		read_bytes -= page_read_bytes;
 		zero_bytes -= page_zero_bytes;
 		upage += PGSIZE;
@@ -753,16 +689,16 @@ load_segment (struct file *file, off_t ofs, uint8_t *upage,
 	return true;
 }
 
-/* USER_STACK에 스택 페이지를 만든다. 성공하면 true를 반환한다. */
+/* Create a PAGE of stack at the USER_STACK. Return true on success. */
 static bool
 setup_stack (struct intr_frame *if_) {
 	bool success = false;
 	void *stack_bottom = (void *) (((uint8_t *) USER_STACK) - PGSIZE);
 
-	/* TODO: stack_bottom에 스택을 매핑하고 페이지를 즉시 점유한다.
-	 * TODO: 성공하면 rsp를 그에 맞게 설정한다.
-	 * TODO: 해당 페이지를 스택 페이지로 표시해야 한다. */
-	/* TODO: 여기에 코드를 작성한다. */
+	/* TODO: Map the stack on stack_bottom and claim the page immediately.
+	 * TODO: If success, set the rsp accordingly.
+	 * TODO: You should mark the page is stack. */
+	/* TODO: Your code goes here */
 
 	return success;
 }

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -9,10 +9,16 @@
 #include "threads/flags.h"
 #include "threads/init.h"
 #include "intrinsic.h"
+#include "devices/input.h"
+#include "filesys/file.h"
+#include "threads/synch.h"
+
+
 
 void syscall_entry (void);
 void syscall_handler (struct intr_frame *);
 static struct lock filesys_lock;
+static struct fd_entry *find_fd_entry(int fd);
 
 /* 시스템 호출.
  *
@@ -41,27 +47,32 @@ syscall_init (void) {
 	list_init(&filesys_lock);
 }
 
+
+/* user가 요청한 fd를 읽어 buffer에 내용을 저장 */
 int read(int fd, void *buffer, unsigned size) {
-	//   fd == 1: 실패
-	if (fd == 1) {
+	/* 인자 기본 검사 */
+	if (fd < 0) {
+		return -1;
+	}
+
+	if (fd == 1) { 	// fd == 1: 실패
 		return -1;
 	}
 	// size 검사
 		if (size == 0) {
 		return 0;
 	}
-	// 버퍼 시작 주소 검사
-	if (buffer == NULL) {
+
+	/* buffer 유효성 검사 */
+	if (buffer == NULL) { // 버퍼 시작 주소 검사
 		return exit(-1);
 	}
-	// buffer 전체 범위 유효성 검사
-	char *start = buffer;
+	char *start = buffer; 	// buffer 전체 범위 검사
 	char *end = start + size -1;
 	char *p= buffer;
 
-
 	for (p = start; p <= end; p++) {
-		if (is_user_vaddr(p) && pml4_get_page(thread_current()->pml4, p) ) {
+		if (is_user_vaddr(p) && pml4_get_page(thread_current()->pml4, p) ) { // p가 사용자 주소 범위 안인지 + p가 페이지 테이블에 매핑되어 있는지 검사
 			continue;
 		}
 		else {
@@ -69,18 +80,47 @@ int read(int fd, void *buffer, unsigned size) {
 		}
 	}
 
+	/* 실제 read를 수행 */
+	size_t i;
+	char *buf = buffer;
 
-	// 실제 read 수행
-	//   stdin이면 input_getc로 buffer에 size만큼 쓰기
-	//   file이면 filesys lock 획득 후 file_read
+	if (fd == 0) { // stdin이면 input_getc로 buffer에 size만큼 쓰기
+		for (i=0; i<size; i++) {
+			buf[i] = input_getc();
+		}
+		return size;
+	}
+	if (fd >= 2) {
+		struct fd_entry *entry = find_fd_entry(fd); // file이면 fd로 entry를 찾는다
+		if (entry == NULL || entry->file == NULL) {
+			return -1;
+		}
+		lock_acquire(&filesys_lock); // file이면 filesys lock 획득 후 file_read
+		off_t read_size = file_read(entry->file, buffer, size);
+		lock_release(&filesys_lock); // file이면 filesys lock 해제
 
-	// file이면 filesys lock 해제
-
-	// 읽은 바이트 수 반환
-
-
-
+		return read_size; // 읽은 바이트 수 반환
+	}
 }
+
+/* fd를 받아 fd_entry를 찾아서 반환한다 */
+static struct fd_entry *
+find_fd_entry(int fd) {
+	struct thread *curr = thread_current();
+	struct list_elem *e;
+
+	for (e = list_begin(&curr->fd_list);
+		 e != list_end(&curr->fd_list);
+		 e = list_next(e)) {
+		struct fd_entry *entry = list_entry(e, struct fd_entry, elem);
+
+		if (entry->fd == fd) {
+			return entry;
+		}
+	}
+	return NULL;
+}
+
 
 /* 메인 시스템 호출 인터페이스 */
 void

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -44,7 +44,7 @@ syscall_init (void) {
 	 * FLAG_FL을 마스킹한다. */
 	write_msr(MSR_SYSCALL_MASK,
 			FLAG_IF | FLAG_TF | FLAG_DF | FLAG_IOPL | FLAG_AC | FLAG_NT);
-	list_init(&filesys_lock);
+	lock_init(&filesys_lock);
 }
 
 
@@ -101,6 +101,7 @@ int read(int fd, void *buffer, unsigned size) {
 
 		return read_size; // 읽은 바이트 수 반환
 	}
+	return -1;
 }
 
 /* fd를 받아 fd_entry를 찾아서 반환한다 */
@@ -143,6 +144,14 @@ syscall_handler (struct intr_frame *f UNUSED) {
 			putbuf((const char *) f->R.rsi, (size_t) f->R.rdx);
 			f->R.rax = f->R.rdx;
 		}
+		break;
+	}
+
+	case SYS_READ: {
+		/* read(fd, buffer, size)의 인자는 syscall_entry가 저장한 레지스터에서
+		 * 꺼낸다. rdi는 fd, rsi는 사용자 버퍼 주소, rdx는 읽을 바이트 수다.
+		 * 시스템 콜 반환값도 rax로 돌아가므로 read() 결과를 f->R.rax에 저장한다. */
+		f->R.rax = read((int) f->R.rdi, (void *) f->R.rsi, (unsigned) f->R.rdx);
 		break;
 	}
 	

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -12,6 +12,7 @@
 
 void syscall_entry (void);
 void syscall_handler (struct intr_frame *);
+static struct lock filesys_lock;
 
 /* 시스템 호출.
  *
@@ -37,6 +38,48 @@ syscall_init (void) {
 	 * FLAG_FL을 마스킹한다. */
 	write_msr(MSR_SYSCALL_MASK,
 			FLAG_IF | FLAG_TF | FLAG_DF | FLAG_IOPL | FLAG_AC | FLAG_NT);
+	list_init(&filesys_lock);
+}
+
+int read(int fd, void *buffer, unsigned size) {
+	//   fd == 1: 실패
+	if (fd == 1) {
+		return -1;
+	}
+	// size 검사
+		if (size == 0) {
+		return 0;
+	}
+	// 버퍼 시작 주소 검사
+	if (buffer == NULL) {
+		return exit(-1);
+	}
+	// buffer 전체 범위 유효성 검사
+	char *start = buffer;
+	char *end = start + size -1;
+	char *p= buffer;
+
+
+	for (p = start; p <= end; p++) {
+		if (is_user_vaddr(p) && pml4_get_page(thread_current()->pml4, p) ) {
+			continue;
+		}
+		else {
+			return exit(-1); // exit syscall 구현 에정
+		}
+	}
+
+
+	// 실제 read 수행
+	//   stdin이면 input_getc로 buffer에 size만큼 쓰기
+	//   file이면 filesys lock 획득 후 file_read
+
+	// file이면 filesys lock 해제
+
+	// 읽은 바이트 수 반환
+
+
+
 }
 
 /* 메인 시스템 호출 인터페이스 */


### PR DESCRIPTION
## 변경 내용
- argument passing 관련 `process.c` 변경을 반영했습니다.
- `SYS_READ`를 syscall handler에 연결했습니다.
- `read(fd, buffer, size)` 기본 흐름을 구현했습니다.
  - `fd == 0`은 stdin에서 `input_getc()`로 읽습니다.
  - `fd == 1`은 read 불가로 `-1`을 반환합니다.
  - `fd >= 2`는 fd list에서 `fd_entry`를 찾아 `file_read()`를 호출합니다.
- 파일 디스크립터 관리를 위해 `fd_entry`, `fd_list`, `next_fd` 구조와 초기화를 추가했습니다.
- 파일 시스템 접근 보호를 위해 `filesys_lock` 초기화를 추가했습니다.

## 테스트
| 테스트 | 결과 |
| --- | --- |
| `make -C pintos/userprog` | FAIL: `return exit(-1)` 처리 미완성으로 컴파일 실패 |

## 리뷰 포인트
- 잘못된 사용자 버퍼 처리에서 `return exit(-1)` 대신 Pintos 방식의 exit helper로 정리해야 합니다.
- `open()`이 아직 fd_list에 `fd_entry`를 추가하지 않으면 `fd >= 2` read는 항상 실패합니다.
- `process.c` 변경이 기존 argument passing 의도와 맞게 포함되었는지 확인 부탁드립니다.
- buffer 유효성 검사는 현재 바이트 단위로 수행합니다.

## PR 체크리스트
- [x] 관련 테스트를 직접 돌렸습니다.
- [x] 테스트 결과를 적었습니다.
- [x] 남은 리스크(리뷰 포인트)가 있으면 적었습니다.
