### PR TITLE
[syscall, process] userprog의 기초 syscall 방어 로직과 파일 디스크립터 기반 기본 흐름을 추가

### DIFF
--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -112,7 +112,7 @@ struct  thread {
 	uint64_t *pml4;                     /* 4단계 페이지 맵. */
 	struct list fd_table;         	   /* 파일 디스크립터 테이블 */
 	int next_fd;						/* 다음에 배정할 fd entry의 fd 넘버 */
-	uint64_t exit_status;               /* 종료 코드 */
+	int exit_status;               /* 종료 코드 */
 #endif
 #ifdef VM
 	/* 스레드가 소유한 전체 가상 메모리용 테이블. */

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -5,6 +5,7 @@
 #include <list.h>
 #include <stdint.h>
 #include "threads/interrupt.h"
+#include "filesys/file.h"
 #ifdef VM
 #include "vm/vm.h"
 #endif
@@ -104,11 +105,12 @@ struct  thread {
 	struct list_elem elem;              /* 리스트 원소. */
 	struct list_elem allelem;           /* 전체 리스트용 원소 */
 
-	uint64_t exit_status;               /* 종료 코드 */
-
 #ifdef USERPROG
 	/* `userprog/process.c`가 관리한다. */
 	uint64_t *pml4;                     /* 4단계 페이지 맵. */
+	struct list fd_table;         	   /* 파일 디스크립터 테이블 */
+	int next_fd;						/* 다음에 배정할 fd entry의 fd 넘버 */
+	uint64_t exit_status;               /* 종료 코드 */
 #endif
 #ifdef VM
 	/* 스레드가 소유한 전체 가상 메모리용 테이블. */
@@ -118,6 +120,12 @@ struct  thread {
 	/* `thread.c`가 관리한다. */
 	struct intr_frame tf;               /* 문맥 전환용 정보. */
 	unsigned magic;                     /* 스택 오버플로를 감지한다. */
+};
+
+struct fd_entry {
+	int fd;
+	struct file *file;
+	struct list_elem elem;
 };
 
 /* 고정소수점 */

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -5,7 +5,9 @@
 #include <list.h>
 #include <stdint.h>
 #include "threads/interrupt.h"
+#ifdef USERPROG
 #include "filesys/file.h"
+#endif
 #ifdef VM
 #include "vm/vm.h"
 #endif

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -134,7 +134,7 @@ struct fd_entry {
 #define F (1 << 14)
 #define INT_TO_FP(n) ((n) * F)                  /* 정수를 고정소수점으로 변환 */
 #define FP_TO_INT_ZERO(x) ((x) / F)             /* 고정소수점을 정수로 변환, 0을 향해 반올림 */
-#define FP_TO_INT_ROUND(x) \            
+#define FP_TO_INT_ROUND(x) \ 
 	((x) >= 0 ? (((x) + F / 2) / F) : (((x) - F / 2) / F)) /* 고정소수점을 정수로 변환, 가장 가까운 정수로 반올림 */
 #define FP_ADD(x, y) ((x) + (y))                /* x와 y 더하기 */
 #define FP_SUB(x, y) ((x) - (y))                /* x에서 y 빼기 */

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -627,12 +627,14 @@ init_thread(struct thread *t, const char *name, int priority)
 	t->wait_on_lock = NULL;
 	list_init(&t->donations);
 
+	t->nice = 0;
+	t->recent_cpu = 0;
+
+#ifdef USERPROG
 	list_init(&t->fd_table);
 	t->next_fd = 2;
 	t->exit_status = 0;
-
-	t->nice = 0;
-	t->recent_cpu = 0;
+#endif
 
 	t->magic = THREAD_MAGIC;
 }

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -230,7 +230,9 @@ tid_t thread_create(const char *name, int priority,
 	if (t != thread_current()) {
 		t->nice = thread_current()->nice;
 		t->recent_cpu = thread_current()->recent_cpu;
+		if (thread_mlfqs) {
 		update_priority(t);
+		}
 	}
 
 	list_push_back(&all_list, &t->allelem);

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -627,6 +627,10 @@ init_thread(struct thread *t, const char *name, int priority)
 	t->wait_on_lock = NULL;
 	list_init(&t->donations);
 
+	list_init(&t->fd_table);
+	t->next_fd = 2;
+	t->exit_status = 0;
+
 	t->nice = 0;
 	t->recent_cpu = 0;
 

--- a/pintos/userprog/exception.c
+++ b/pintos/userprog/exception.c
@@ -77,9 +77,10 @@ kill (struct intr_frame *f) {
 		case SEL_UCSEG:
 			/* 사용자 코드 세그먼트이므로 예상대로 사용자 예외다. 사용자
 			   프로세스를 종료한다. */
-			printf ("%s: dying due to interrupt %#04llx (%s).\n",
+			thread_current()->exit_status = -1;
+			/*printf ("%s: dying due to interrupt %#04llx (%s).\n",
 					thread_name (), f->vec_no, intr_name (f->vec_no));
-			intr_dump_frame (f);
+			intr_dump_frame (f);*/
 			thread_exit ();
 
 		case SEL_KCSEG:
@@ -124,7 +125,6 @@ page_fault (struct intr_frame *f) {
 	   확실히 읽기 위해서뿐이었다. */
 	intr_enable ();
 
-
 	/* 원인을 판별한다. */
 	not_present = (f->error_code & PF_P) == 0;
 	write = (f->error_code & PF_W) != 0;
@@ -140,11 +140,12 @@ page_fault (struct intr_frame *f) {
 	page_fault_cnt++;
 
 	/* 실제 폴트라면 정보를 출력하고 종료한다. */
-	printf ("Page fault at %p: %s error %s page in %s context.\n",
+	/*printf ("Page fault at %p: %s error %s page in %s context.\n",
 			fault_addr,
 			not_present ? "not present" : "rights violation",
 			write ? "writing" : "reading",
 			user ? "user" : "kernel");
+	*/
 	kill (f);
 }
 

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -504,8 +504,7 @@ load (const char *file_name, struct intr_frame *if_) {
 	/* 시작 주소를 설정한다. */
 	if_->rip = ehdr.e_entry;
 
-	/* TODO: Your code goes here.
-	/* TODO: Implement argument passing (see project2/argument_passing.html). */
+	/* Implement argument passing (see project2/argument_passing.html). */
 	/* 스택에 토큰 올리기 */
 	// 스택 맨 위에 명령줄 문자열 삽입한다
 	char *arg_addr[MAX_ARGC];

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -1,5 +1,7 @@
 #include "userprog/syscall.h"
 #include <stdio.h>
+#include <stdlib.h>
+#include "filesys/filesys.h"
 #include <syscall-nr.h>
 #include "threads/interrupt.h"
 #include "threads/thread.h"
@@ -9,9 +11,19 @@
 #include "threads/flags.h"
 #include "threads/init.h"
 #include "intrinsic.h"
+#include "threads/vaddr.h"
+#include "threads/mmu.h"
 
 void syscall_entry (void);
 void syscall_handler (struct intr_frame *);
+
+static void validate_user_ptr(const void *ptr);
+static void validate_user_buffer(const void *buffer, size_t size);
+static void validate_user_string(const char *str);
+static void kill_process_due_to_bad_user_memory(void);
+static struct fd_entry * find_fd_entry (int fd, struct list *fd_table);
+static struct fd_entry * create_fd_entry (struct file* file);
+static void remove_fd_entry (struct fd_entry *entry);
 
 /* 시스템 호출.
  *
@@ -43,22 +55,61 @@ syscall_init (void) {
 void
 syscall_handler (struct intr_frame *f UNUSED) {
 	// TODO: Your implementation goes here.
-
 	struct thread *t = thread_current();
 
 	switch (f->R.rax)
 	{
+	case SYS_OPEN: {
+		const char * filename = (const char *)f->R.rdi;
+		validate_user_string(filename);
+		struct file *file = filesys_open(filename);
+		if (file == NULL) {
+			f->R.rax = -1;
+		} else {
+			struct fd_entry *fd_entry = create_fd_entry(file);
+			if (fd_entry == NULL) {
+				file_close(file);
+				f->R.rax = -1;
+			} else {
+				list_push_back(&thread_current()->fd_table, &fd_entry->elem);
+				f->R.rax = fd_entry->fd;
+			}
+		}
+		break;
+	}
+
+	case SYS_CREATE: {
+		const char * filename = (const char *)f->R.rdi;
+		size_t initial_size = f->R.rsi;
+		validate_user_string(filename);
+		f->R.rax = filesys_create(filename, initial_size);
+		break;
+	}
+
 	case SYS_EXIT: {
 		uint64_t status = f->R.rdi;
-		//t->exit_status = status;
+		t->exit_status = status;
 		thread_exit ();
 		break;
 	}
 
 	case SYS_WRITE: {
-		if ((int) f->R.rdi == 1) {
-			putbuf((const char *) f->R.rsi, (size_t) f->R.rdx);
-			f->R.rax = f->R.rdx;
+		int fd = (int) f->R.rdi;
+		const void * buffer = (const void *)f->R.rsi;
+		size_t size = f->R.rdx;
+
+		if (fd == 1) {
+			validate_user_buffer(buffer, size);
+			putbuf(buffer, (size_t) f->R.rdx);
+			f->R.rax = size;
+		} else {
+			struct fd_entry *fd_entry = find_fd_entry(fd, &thread_current()->fd_table);
+			if (fd_entry == NULL) {
+				f->R.rax = -1;
+			} else {
+				validate_user_buffer(buffer, size);
+				f->R.rax = file_write(fd_entry->file, buffer, size);
+			}
 		}
 		break;
 	}
@@ -70,4 +121,73 @@ syscall_handler (struct intr_frame *f UNUSED) {
 	default:
 		break;
 	}
+}
+
+static void validate_user_ptr(const void *ptr) {
+	if	(ptr == NULL) {
+		kill_process_due_to_bad_user_memory();
+	} else if (!is_user_vaddr(ptr)) {
+		kill_process_due_to_bad_user_memory();
+	} else if (pml4_get_page(thread_current()->pml4, ptr) == NULL) {
+		kill_process_due_to_bad_user_memory();
+	}
+}
+
+static void validate_user_buffer(const void *buffer, size_t size){
+	if (size == 0) {
+		return;
+	} else {
+		uint8_t *p = (uint8_t *) buffer;
+		for (size_t i = 0; i < size; i++) {
+			validate_user_ptr(p + i);
+		}
+	}
+}
+
+static void validate_user_string(const char *str) {
+	if (str == NULL){
+		kill_process_due_to_bad_user_memory();
+	} else {
+		const char *p = str;
+		while (true) {
+			validate_user_ptr(p);
+			if (*p == '\0') {
+				break;
+			}
+			p++;
+		}
+	}
+}
+
+static void kill_process_due_to_bad_user_memory(void) {
+	thread_current()->exit_status = -1;
+	thread_exit();
+}
+
+static struct fd_entry * find_fd_entry (int fd, struct list *fd_table) {
+	struct list_elem *e;
+	for (e = list_begin(fd_table); e != list_end(fd_table); e = list_next(e)) {
+		struct fd_entry *fd_entry = list_entry(e, struct fd_entry, elem);
+		if (fd_entry->fd == fd) {
+			return fd_entry;
+		}
+	}
+	return NULL;
+}
+
+static struct fd_entry * create_fd_entry (struct file* file) {
+	struct fd_entry *entry = malloc(sizeof(struct fd_entry));
+	if (entry == NULL) {
+		return NULL;
+	}
+	entry->fd = thread_current()->next_fd;
+	entry->file = file;
+	thread_current()->next_fd++;
+	return entry;
+}
+
+static void remove_fd_entry (struct fd_entry *entry) {
+	list_remove(&entry->elem);
+	file_close(entry->file);
+	free(entry);
 }


### PR DESCRIPTION
## 변경 내용
이번 PR에서는 userprog의 기초 syscall 방어 로직과 파일 디스크립터 기반 기본 흐름을 추가했습니다.

### 주요 변경 사항:
유저 포인터 검증 helper 추가
validate_user_ptr()
validate_user_buffer()
validate_user_string()
잘못된 유저 메모리 접근 시 exit(-1)로 종료하는 흐름 정리
fd_table, next_fd, fd_entry 기반 기본 파일 디스크립터 구조 추가

### 테스트를 위한 임시구현:
SYS_OPEN
filesys_open() 결과를 fd_entry로 관리
성공 시 fd 반환, 실패 시 -1 반환

SYS_CREATE
filename 문자열 검증 후 create 수행

SYS_WRITE
fd == 1인 stdout 경로와 일반 파일 fd 경로 분리
일반 파일은 fd_table lookup 후 file_write() 수행
exception 경로의 bad access 테스트 출력 정리

### 의도
open/create/write와 bad pointer / bad memory access 축을 먼저 안정화하고,
이후 read, fork/exec/wait, rox 구현으로 이어가기 위한 기반을 만드는 것을 목표로 했습니다.

## 테스트
| 테스트 | 결과 |
| --- | --- |
| `args-* ` | PASS |
| `halt ` | PASS |
| `exit ` | PASS |
| `create-*` | PASS |
| `open-* ` | PASS |
| `close-* ` | PASS |
| `write-* ` | PASS |
| `bad-*` | PASS |
| `read-*` | FAIL |
| `fork-*` | FAIL |
| `exec-*` | FAIL |
| `multi-*` | FAIL |
| `wait-*` | FAIL |
| `rox-*` | FAIL |

## 리뷰 포인트

### 참고 / 남은 작업
read syscall 처리되는지 머지하고 체크
parent-child / exec / wait 구조 처리되는지 머지하고 체크
실행 파일 deny_write 처리
파일 관련 lock 정책 정리

## PR 체크리스트
- [x] 관련 테스트를 직접 돌렸습니다.
- [x] 테스트 결과를 적었습니다.
- [x] 남은 리스크(리뷰 포인트)가 있으면 적었습니다.
